### PR TITLE
feat: install shellcheck, shellspec and gengetoptions via Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__
 /lib
 /lib64
 
+# getoptions parser generator binaries for Makefile
+/.bin
+
 # Installer logs
 pip-log.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,51 @@
+
+PATH := $(PATH):.bin/:.bin/shellspec_repo
+GETOPTIONS_RELEASE := v3.3.0
+SHELLSPEC_RELEASE := 0.28.1  # CI uses latest version. If CI fails, bump up this version.
+SHELLCHECK_RELEASE := v0.9.0  # CI uses latest version. If CI fails, bump up this version.
+
+UNAME := $(shell uname -is)
+
 all: gengetoptions
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
-	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort	
+	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-# requires getoptions to be installed
-# installing getoptions locally: https://github.com/ko1nksm/getoptions/#installation
-gengetoptions: ## use getoptions to generate argument parsing
+gengetoptions: .bin/.bin_is_ready ## use getoptions to generate argument parsing
 	gengetoptions embed --overwrite atlas
 
-# requires shellspec to be installed
-# installing shellspec locally: https://github.com/shellspec/shellspec/#installation
-# note: the CI uses the latest stable version available in brew: `brew tap shellspec/shellspec`, `brew install shellspec`
-test: ## automated testing using shellspec
+test: .bin/.bin_is_ready ## automated testing using shellspec
 	shellspec
+
+unzip_shellcheck:  # utility to unzip shellcheck into .bin
+	cd .bin && tar -xf shellcheck.tar.xz shellcheck-$(SHELLCHECK_RELEASE)/shellcheck
+	mv .bin/shellcheck-$(SHELLCHECK_RELEASE)/shellcheck .bin/shellcheck
+
+
+.bin/.bin_is_ready:  ## install required binaries for testing and development
+	rm -rf .bin
+	mkdir .bin
+	# Install getoptions according to https://github.com/ko1nksm/getoptions/#installation
+	wget https://github.com/ko1nksm/getoptions/releases/download/$(GETOPTIONS_RELEASE)/getoptions -O ./.bin/getoptions
+	wget https://github.com/ko1nksm/getoptions/releases/download/$(GETOPTIONS_RELEASE)/gengetoptions -O .bin/gengetoptions
+
+	git -c advice.detachedHead=false \
+	    clone https://github.com/shellspec/shellspec.git --depth=1 --branch=$(SHELLSPEC_RELEASE) .bin/shellspec_repo
+
+ifeq ($(UNAME), Linux x86_64)
+	# install shellcheck on Linux x86_64
+	wget https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_RELEASE)/shellcheck-$(SHELLCHECK_RELEASE).linux.x86_64.tar.xz -O .bin/shellcheck.tar.xz
+	make unzip_shellcheck
+else ifeq ($(UNAME), Darwin x86_64)
+	# install shellcheck on MacOSX
+	wget https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_RELEASE)/shellcheck-$(SHELLCHECK_RELEASE).darwin.x86_64.tar.xz -O .bin/shellcheck.tar.xz
+	make unzip_shellcheck
+else
+	@echo "WARNING: Makefile don't know hot to install shellcheck on $(UNAME)."
+	@echo "         Please install it manually from https://github.com/koalaman/shellcheck#installing"
+	@echo "         If you run into this, please consider fixing Makefile for your Operating System"
+endif
+
+	chmod +x .bin/getoptions .bin/gengetoptions
+	touch .bin/.bin_is_ready

--- a/README.rst
+++ b/README.rst
@@ -52,11 +52,10 @@ Atlas can also be used without a configuration file by using the flags below aft
 Running Automated Tests Locally
 -------------------------------
 
-**Install**
+**Installing ShellCheck**
 
-* `ShellSpec <https://github.com/shellspec/shellspec#installation>`_
-* `ShellCheck <https://github.com/koalaman/shellcheck#installing>`_
-* `getoptions <https://github.com/ko1nksm/getoptions#installation>`_
+``Makefile`` attempts to install ShellCheck, but if it fails it can be
+installed as shown in `the ShellCheck installation guide <https://github.com/koalaman/shellcheck#installing>`_.
 
 **Run**
 

--- a/atlas
+++ b/atlas
@@ -8,7 +8,7 @@ parser_definition() {
 				"Atlas is a CLI tool that has essentially one command: \`atlas pull\`\n \nAtlas defaults to using a configuration file named \`atlas.yml\` placed\nin the root directory. Configuration file:\n \npull:\n  branch: <branch-name>\n  directory <directory-name>\n  repository: <organization-name>/<repository-name>\n \nAtlas can also use a configuration file in a different path using the \`--config\` flag\nafter \`atlas\`: \`atlas pull --config config.yml\`.\n \nAtlas can also be used without a configuration file by using the flags below after\n\`atlas pull\`.\n \n\`-b\` or \`--branch\`\n\`-r\` or \`--repository\`\n\`-d\` or \`--directory\`" ''
 	msg 	 -- '' 'Commands:'
 	cmd pull -- "pull"
-	disp    :usage  -h --help	
+	disp    :usage  -h --help
 }
 
 parser_definition_pull() {
@@ -21,7 +21,7 @@ parser_definition_pull() {
 	param		DIRECTORY	-d	--directory			-- "Directory (name of the repository) containing translations to be downloaded"
 	flag		VERBOSE		-v	--verbose			-- "verbose output to terminal"
 	flag		SILENT		-s	--silent			-- "no output to terminal"
-	disp    :usage_pull  -h --help	
+	disp    :usage_pull  -h --help
 }
 # @end
 
@@ -300,7 +300,7 @@ pull_translations() {
   else
     git remote add -f origin "$remote_url"
   fi
-  
+
   # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
   if [ -z "$SILENT" ];
   then
@@ -382,10 +382,10 @@ if [ $# -gt 0 ]; then
       then
         display_pull_params
       fi
-      # allow mocking pull_translations 
+      # allow mocking pull_translations
       __ begin_pull_translations_mock __
       pull_translations
-      __ end_pull_translations_mock __      
+      __ end_pull_translations_mock __
       ;;
 		--) # no subcommand, arguments only
 	esac


### PR DESCRIPTION
This PR is a nice-to-have feature in preparation to completing the remaining features of atlas. It's useful to avoid manual installation of requirements.

Changes
-----------

 - Automated installation for `make test` and `make gengetoptions` dependencies.
 - Updated README to reflect manual `shellcheck` installation is needed on Operating Systems other than Linux 64 and Mac OS 64 bits.
 - Re-generated `atlas` gengetoptions


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.