### PR TITLE
feat: add --dry-run command to print tree without copying files

### DIFF
--- a/atlas
+++ b/atlas
@@ -22,6 +22,7 @@ parser_definition_pull() {
 	param		FILTER	    -f	--filter			-- "List of patterns to select which files and sub-directories to checkout."
 	flag		VERBOSE		-v	--verbose			-- "verbose output to terminal"
 	flag		SILENT		-s	--silent			-- "no output to terminal"
+	flag		DRY_RUN		-n	--dry-run			-- "Do not copy files. Print sparse-checkout rules, git checkout tree and copied tree."
 	disp    :usage_pull  -h --help
 }
 # @end
@@ -118,6 +119,7 @@ DIRECTORY=''
 FILTER=''
 VERBOSE=''
 SILENT=''
+DRY_RUN=''
 REST=''
 parse_pull() {
   OPTIND=$(($#+1))
@@ -130,7 +132,7 @@ parse_pull() {
       -[brdf]?*) OPTARG=$1; shift
         eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
         ;;
-      -[vsh]?*) OPTARG=$1; shift
+      -[vsnh]?*) OPTARG=$1; shift
         eval 'set -- "${OPTARG%"${OPTARG#??}"}" -"${OPTARG#??}"' ${1+'"$@"'}
         OPTARG= ;;
     esac
@@ -169,6 +171,11 @@ parse_pull() {
         [ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
         eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
         SILENT="$OPTARG"
+        ;;
+      '-n'|'--dry-run')
+        [ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
+        eval '[ ${OPTARG+x} ] &&:' && OPTARG='1' || OPTARG=''
+        DRY_RUN="$OPTARG"
         ;;
       '-h'|'--help')
         usage_pull
@@ -209,6 +216,7 @@ Options:
   -f, --filter FILTER         List of patterns to select which files and sub-directories to checkout.
   -v, --verbose               verbose output to terminal
   -s, --silent                no output to terminal
+  -n, --dry-run               Do not copy files. Print sparse-checkout rules, git checkout tree and copied tree.
   -h, --help                  
 GETOPTIONSHERE
 }
@@ -288,6 +296,16 @@ display_pull_params() {
   echo " - filter: ${pull_filter:-Not Specified}"
 }
 
+print_directory_tree() {
+    # Use `$ tree` when available with a fallback to `$ find . -type f`
+    if ! tree 2>/dev/null;
+    then
+        echo
+        find . -type f
+        echo
+    fi
+}
+
 pull_translations() {
   if [ -z "$SILENT" ];
   then
@@ -351,8 +369,25 @@ pull_translations() {
   # Retrieve translation files from the repo
   git pull $quiet origin "$pull_branch"
 
+  # Extra debugging output for sparse-checkout with --dry-run flag
+  if [ "$DRY_RUN" ] && [ -z "$SILENT" ];
+  then
+      echo "Done."
+
+      echo "Printing all 'git sparse-checkout' rules:"
+      git sparse-checkout list
+  fi
+
   # Remove .git directory
   rm -rf .git
+
+  if [ "$DRY_RUN" ] && [ -z "$SILENT" ];
+  then
+      echo "Done."
+
+      echo "Listing the sparse-checkout file tree from the checked-out repository:"
+      print_directory_tree
+  fi
 
   # Leave the temp dir
   cd ..
@@ -365,12 +400,35 @@ pull_translations() {
     echo "Copying translations from \"./translations_TEMP/$pull_directory\" to \"./$pull_directory\"..."
   fi
 
+  if [ "$DRY_RUN" ];
+  then
+    target_directory=translations_traget_TEMP
+    mkdir -p translations_traget_TEMP
+  else
+    target_directory=.
+  fi
+
   # Copy translation files out of the temp dir
   if [ "$pull_directory" ];
   then
-    cp -r translations_TEMP/"$pull_directory"/* ./
+    cp -r translations_TEMP/"$pull_directory"/* $target_directory/
   else
-    cp -r translations_TEMP/* ./
+    cp -r translations_TEMP/* $target_directory/
+  fi
+
+  if [ "$DRY_RUN" ];
+  then
+    if [ -z "$SILENT" ];
+    then
+      echo "Done."
+
+      echo "Listing the copied files tree in the local file system:"
+      (cd translations_traget_TEMP || exit; print_directory_tree)
+      echo "Done."
+
+      echo "Removing temporary translations_traget_TEMP directory..."
+    fi
+    rm -rf translations_traget_TEMP
   fi
 
   # finished "Copying translations from <temp dir> to <dest dir>..." step
@@ -391,7 +449,12 @@ pull_translations() {
 
     # finished pulling translations!
     echo ""
-    echo "Translations pulled successfully!"
+    if [ "$DRY_RUN" ];
+    then
+      echo "Translations pulled successfully in dry-run mode without copying!"
+    else
+      echo "Translations pulled successfully!"
+    fi
   fi
 }
 

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -108,3 +108,55 @@ git sparse-checkout add pull_directory/**/fr_CA.*
 git pull origin pull_branch'
   End
 End
+
+Describe 'Pull with dry-run flag'
+  Include ./atlas
+
+  git() {
+      echo "git $@"
+  }
+
+  cp() {
+    echo "cp $@"
+  }
+
+  tree() {
+    echo "tree"
+  }
+
+
+  setup() { pull_directory="pull_directory" pull_repository="pull_repository" pull_branch="pull_branch"; DRY_RUN=1; VERBOSE=1; }
+  BeforeEach 'setup'
+
+  It 'print file trees'
+    When call pull_translations
+    The lines of output should equal 27
+    The output should eq "Creating a temporary Git repository to pull translations into \"./translations_TEMP\"...
+git init -b main
+git remote add -f origin https://github.com/pull_repository.git
+Done.
+Pulling translations into \"./translations_TEMP/pull_directory\"...
+git sparse-checkout set !*
+git sparse-checkout add pull_directory/
+git pull origin pull_branch
+Done.
+Printing all 'git sparse-checkout' rules:
+git sparse-checkout list
+Done.
+Listing the sparse-checkout file tree from the checked-out repository:
+tree
+Done.
+Copying translations from \"./translations_TEMP/pull_directory\" to \"./pull_directory\"...
+cp -r translations_TEMP/pull_directory/* translations_traget_TEMP/
+Done.
+Listing the copied files tree in the local file system:
+tree
+Done.
+Removing temporary translations_traget_TEMP directory...
+Done.
+Removing temporary directory...
+Done.
+
+Translations pulled successfully in dry-run mode without copying!"
+  End
+End


### PR DESCRIPTION
Usage `$ atlas pull --dry-run` would print the following:

 - `git sparse-checkout` configuration
 - `git checkout` tree
 - `cp -r` tree

Full docs are in #8.

Using this command won't copy the files into local directory.



References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes.
