### PR TITLE
feat: add --filter parameter to select specific languages/files

### DIFF
--- a/atlas
+++ b/atlas
@@ -8,7 +8,7 @@ parser_definition() {
 				"Atlas is a CLI tool that has essentially one command: \`atlas pull\`\n \nAtlas defaults to using a configuration file named \`atlas.yml\` placed\nin the root directory. Configuration file:\n \npull:\n  branch: <branch-name>\n  directory <directory-name>\n  repository: <organization-name>/<repository-name>\n \nAtlas can also use a configuration file in a different path using the \`--config\` flag\nafter \`atlas\`: \`atlas pull --config config.yml\`.\n \nAtlas can also be used without a configuration file by using the flags below after\n\`atlas pull\`.\n \n\`-b\` or \`--branch\`\n\`-r\` or \`--repository\`\n\`-d\` or \`--directory\`" ''
 	msg 	 -- '' 'Commands:'
 	cmd pull -- "pull"
-	disp    :usage  -h --help	
+	disp    :usage  -h --help
 }
 
 parser_definition_pull() {
@@ -19,9 +19,10 @@ parser_definition_pull() {
 	param		BRANCH		-b	--branch			-- "A branch of translation files"
 	param		REPOSITORY	-r	--repository		-- "The repository containing translation files"
 	param		DIRECTORY	-d	--directory			-- "Directory (name of the repository) containing translations to be downloaded"
+	param		FILTER	    -f	--filter			-- "List of patterns to select which files and sub-directories to checkout."
 	flag		VERBOSE		-v	--verbose			-- "verbose output to terminal"
 	flag		SILENT		-s	--silent			-- "no output to terminal"
-	disp    :usage_pull  -h --help	
+	disp    :usage_pull  -h --help
 }
 # @end
 
@@ -114,6 +115,7 @@ CONFIG=''
 BRANCH=''
 REPOSITORY=''
 DIRECTORY=''
+FILTER=''
 VERBOSE=''
 SILENT=''
 REST=''
@@ -125,7 +127,7 @@ parse_pull() {
         eval 'set -- "${OPTARG%%\=*}" "${OPTARG#*\=}"' ${1+'"$@"'}
         ;;
       --no-*|--without-*) unset OPTARG ;;
-      -[brd]?*) OPTARG=$1; shift
+      -[brdf]?*) OPTARG=$1; shift
         eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
         ;;
       -[vsh]?*) OPTARG=$1; shift
@@ -152,6 +154,11 @@ parse_pull() {
         [ $# -le 1 ] && set "required" "$1" && break
         OPTARG=$2
         DIRECTORY="$OPTARG"
+        shift ;;
+      '-f'|'--filter')
+        [ $# -le 1 ] && set "required" "$1" && break
+        OPTARG=$2
+        FILTER="$OPTARG"
         shift ;;
       '-v'|'--verbose')
         [ "${OPTARG:-}" ] && OPTARG=${OPTARG#*\=} && set "noarg" "$1" && break
@@ -199,6 +206,7 @@ Options:
   -b, --branch BRANCH         A branch of translation files
   -r, --repository REPOSITORY The repository containing translation files
   -d, --directory DIRECTORY   Directory (name of the repository) containing translations to be downloaded
+  -f, --filter FILTER         List of patterns to select which files and sub-directories to checkout.
   -v, --verbose               verbose output to terminal
   -s, --silent                no output to terminal
   -h, --help                  
@@ -243,6 +251,7 @@ set_pull_params() {
       pull_directory=""
       pull_repository="openedx/openedx-translations"
       pull_branch="main"
+      pull_filter=""
     fi
   fi
 
@@ -261,6 +270,13 @@ set_pull_params() {
   then
       pull_branch=$BRANCH
   fi
+
+  if [ "$FILTER" ];
+  then
+      pull_filter="$FILTER"
+  fi
+
+  pull_filter="$(echo "$pull_filter" | tr ',' ' ')"  # Accept comma and/or space separated directories list
 }
 
 display_pull_params() {
@@ -269,6 +285,7 @@ display_pull_params() {
   echo " - directory: ${pull_directory:-Not Specified}"
   echo " - repository: ${pull_repository:-Not Specified}"
   echo " - branch: ${pull_branch:-Not Specified}"
+  echo " - filter: ${pull_filter:-Not Specified}"
 }
 
 pull_translations() {
@@ -300,7 +317,7 @@ pull_translations() {
   else
     git remote add -f origin "$remote_url"
   fi
-  
+
   # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
   if [ -z "$SILENT" ];
   then
@@ -312,9 +329,23 @@ pull_translations() {
   # If a directory is specified, configure git for a sparse checkout
   if [ "$pull_directory" ];
   then
-    git config core.sparseCheckout true
-    git sparse-checkout init
-    git sparse-checkout set "$pull_directory"
+    # Reset git sparse-checkout list of include/exclude files
+    # Tells sparse checkout to ignore all files, except when otherwise noted
+    # See https://www.git-scm.com/docs/git-sparse-checkout for detailed implementation
+    git sparse-checkout set "!*"
+
+    if [ "$pull_filter" ];
+    then
+        for one_filter in $pull_filter;
+        do
+            # Include directories that matches the language pattern e.g. `/ar/`
+            git sparse-checkout add "$pull_directory/**/${one_filter}/**"
+            # Include files that matches the language pattern e.g. `ar.*`
+            git sparse-checkout add "$pull_directory/**/${one_filter}.*"
+        done
+    else
+        git sparse-checkout add "$pull_directory/"
+    fi
   fi
 
   # Retrieve translation files from the repo
@@ -382,10 +413,10 @@ if [ $# -gt 0 ]; then
       then
         display_pull_params
       fi
-      # allow mocking pull_translations 
+      # allow mocking pull_translations
       __ begin_pull_translations_mock __
       pull_translations
-      __ end_pull_translations_mock __      
+      __ end_pull_translations_mock __
       ;;
 		--) # no subcommand, arguments only
 	esac

--- a/example.atlas.yml
+++ b/example.atlas.yml
@@ -2,3 +2,4 @@ pull:
   branch: example_branch
   directory: example_directory
   repository: example_repository
+  filter: example_filter

--- a/manual-testing-example.atlas.yml
+++ b/manual-testing-example.atlas.yml
@@ -2,3 +2,4 @@ pull:
   branch: try-using-bash
   directory: example-translations/repos/json
   repository: brian-smith-tcril/openedx-atlas
+  filter: ar de es_419

--- a/spec/config_spec.sh
+++ b/spec/config_spec.sh
@@ -28,11 +28,12 @@ Describe 'Test Default Config'
 
   It 'sets the default values correctly when no config param is passed and atlas.yml does not exist'
     When run source ./atlas pull
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
     The line 2 of output should equal ' - directory: Not Specified'
     The line 3 of output should equal ' - repository: openedx/openedx-translations'
     The line 4 of output should equal ' - branch: main'
+    The line 5 of output should equal ' - filter: Not Specified'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End
@@ -54,11 +55,12 @@ Describe 'Test example atlas.yml'
 
   It 'reads atlas.yml correctly when no config param is passed'
     When run source ./atlas pull
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
     The line 2 of output should equal ' - directory: example_directory'
     The line 3 of output should equal ' - repository: example_repository'
     The line 4 of output should equal ' - branch: example_branch'
+    The line 5 of output should equal ' - filter: example_filter'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End
@@ -75,11 +77,12 @@ Describe 'Test example.atlas.yml'
 
   It 'reads example.atlas.yml correctly when passed as config param'
     When run source ./atlas pull --config example.atlas.yml
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
     The line 2 of output should equal ' - directory: example_directory'
     The line 3 of output should equal ' - repository: example_repository'
     The line 4 of output should equal ' - branch: example_branch'
+    The line 5 of output should equal ' - filter: example_filter'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End
@@ -95,12 +98,13 @@ Describe 'Test full flags'
   }
 
   It 'correctly reads full flag params'
-    When run source ./atlas pull --directory full_flag_directory --repository full_flag_repository --branch full_flag_branch
-    The lines of output should equal 4
+    When run source ./atlas pull --directory full_flag_directory --repository full_flag_repository --branch full_flag_branch --filter ar,es_419
+    The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
     The line 2 of output should equal ' - directory: full_flag_directory'
     The line 3 of output should equal ' - repository: full_flag_repository'
     The line 4 of output should equal ' - branch: full_flag_branch'
+    The line 5 of output should equal ' - filter: ar es_419'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End
@@ -116,12 +120,13 @@ Describe 'Test short flags'
   }
 
   It 'correctly reads short flag params'
-    When run source ./atlas pull -d short_flag_directory -r short_flag_repository -b short_flag_branch
-    The lines of output should equal 4
+    When run source ./atlas pull -d short_flag_directory -r short_flag_repository -b short_flag_branch -f 'ar es_419'
+    The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
     The line 2 of output should equal ' - directory: short_flag_directory'
     The line 3 of output should equal ' - repository: short_flag_repository'
     The line 4 of output should equal ' - branch: short_flag_branch'
+    The line 5 of output should equal ' - filter: ar es_419'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -29,7 +29,7 @@ Describe 'Pull without directory param'
     The line 12 of output should equal 'Done.'
     The line 13 of output should equal ''
     The line 14 of output should equal 'Translations pulled successfully!'
-    
+
   End
 End
 
@@ -50,23 +50,61 @@ Describe 'Pull with directory param'
 
   It 'calls everything properly'
     When call pull_translations
-    The lines of output should equal 17
+    The lines of output should equal 16
     The line 1 of output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...'
     The line 2 of output should equal 'git init -b main'
     The line 3 of output should equal 'git remote add -f origin https://github.com/pull_repository.git'
     The line 4 of output should equal 'Done.'
     The line 5 of output should equal 'Pulling translations into "./translations_TEMP/pull_directory"...'
-    The line 6 of output should equal 'git config core.sparseCheckout true'
-    The line 7 of output should equal 'git sparse-checkout init'
-    The line 8 of output should equal 'git sparse-checkout set pull_directory'
-    The line 9 of output should equal 'git pull origin pull_branch'
-    The line 10 of output should equal 'Done.'
-    The line 11 of output should equal 'Copying translations from "./translations_TEMP/pull_directory" to "./pull_directory"...'
-    The line 12 of output should equal 'cp -r translations_TEMP/pull_directory/* ./'
-    The line 13 of output should equal 'Done.'
-    The line 14 of output should equal 'Removing temporary directory...'
-    The line 15 of output should equal 'Done.'
-    The line 16 of output should equal ''
-    The line 17 of output should equal 'Translations pulled successfully!'
+    The line 6 of output should equal 'git sparse-checkout set !*'
+    The line 7 of output should equal 'git sparse-checkout add pull_directory/'
+    The line 8 of output should equal 'git pull origin pull_branch'
+    The line 9 of output should equal 'Done.'
+    The line 10 of output should equal 'Copying translations from "./translations_TEMP/pull_directory" to "./pull_directory"...'
+    The line 11 of output should equal 'cp -r translations_TEMP/pull_directory/* ./'
+    The line 12 of output should equal 'Done.'
+    The line 13 of output should equal 'Removing temporary directory...'
+    The line 14 of output should equal 'Done.'
+    The line 15 of output should equal ''
+    The line 16 of output should equal 'Translations pulled successfully!'
+  End
+End
+
+Describe 'Pull filters'
+  Include ./atlas
+
+  git() {
+    echo "git $@"
+  }
+
+  cp() {
+    # Omit output
+    true
+  }
+
+
+  setup() {
+      pull_directory="pull_directory"
+      pull_repository="pull_repository"
+      pull_branch="pull_branch"
+      pull_filter="ar es_419 fr_CA"
+      VERBOSE=0
+      SILENT=1
+  }
+  BeforeEach 'setup'
+
+  It 'sets correct sparse-checkout rules'
+    When call pull_translations
+    The lines of output should equal 10
+    The output should equal 'git init -b main
+git remote add -f origin https://github.com/pull_repository.git
+git sparse-checkout set !*
+git sparse-checkout add pull_directory/**/ar/**
+git sparse-checkout add pull_directory/**/ar.*
+git sparse-checkout add pull_directory/**/es_419/**
+git sparse-checkout add pull_directory/**/es_419.*
+git sparse-checkout add pull_directory/**/fr_CA/**
+git sparse-checkout add pull_directory/**/fr_CA.*
+git pull origin pull_branch'
   End
 End

--- a/spec/verbosity_spec.sh
+++ b/spec/verbosity_spec.sh
@@ -36,8 +36,8 @@ Describe 'Test default verbosity'
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
     When run source ./atlas pull
-    The lines of output should equal 14
-    The line 14 of output should equal 'Translations pulled successfully!'
+    The lines of output should equal 15
+    The line 15 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable GIT_CALLED_VERBOSELY should equal false
@@ -128,8 +128,8 @@ Describe 'Test verbose flag'
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
     When run source ./atlas pull --verbose
-    The lines of output should equal 14
-    The line 14 of output should equal 'Translations pulled successfully!'
+    The lines of output should equal 15
+    The line 15 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal false
     The variable GIT_CALLED_NOT_QUIETLY should equal true
     The variable GIT_CALLED_VERBOSELY should equal true
@@ -144,8 +144,8 @@ Describe 'Test verbose flag'
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
     When run source ./atlas pull -v
-    The lines of output should equal 14
-    The line 14 of output should equal 'Translations pulled successfully!'
+    The lines of output should equal 15
+    The line 15 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal false
     The variable GIT_CALLED_NOT_QUIETLY should equal true
     The variable GIT_CALLED_VERBOSELY should equal true


### PR DESCRIPTION
Usage:

    $ atlas pull --filter=ar,es_419

This filters (includes) directories named `ar` and `es_419` and files named `ar.*` and `es_419`.

Full docs are available in a separate PR #8 

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern.