### PR TITLE
feat: accept multiple directories with destination for each

### DIFF
--- a/atlas
+++ b/atlas
@@ -12,13 +12,12 @@ parser_definition() {
 }
 
 parser_definition_pull() {
-	setup   REST help:usage_pull -- \
-		"Usage: atlas pull [options...] [arguments...]"
+	setup   PULL_REST help:usage_pull -- \
+		"Usage: atlas pull [options...] [directory mappings...]"
 	msg -- 'Options:'
 	param		CONFIG			--config			-- "path to alternative atlas.yaml configuration file"
 	param		BRANCH		-b	--branch			-- "A branch of translation files"
 	param		REPOSITORY	-r	--repository		-- "The repository containing translation files"
-	param		DIRECTORY	-d	--directory			-- "Directory (name of the repository) containing translations to be downloaded"
 	param		FILTER	    -f	--filter			-- "List of patterns to select which files and sub-directories to checkout."
 	flag		VERBOSE		-v	--verbose			-- "verbose output to terminal"
 	flag		SILENT		-s	--silent			-- "no output to terminal"
@@ -114,11 +113,10 @@ GETOPTIONSHERE
 CONFIG=''
 BRANCH=''
 REPOSITORY=''
-DIRECTORY=''
 FILTER=''
 VERBOSE=''
 SILENT=''
-REST=''
+PULL_REST=''
 parse_pull() {
   OPTIND=$(($#+1))
   while OPTARG= && [ $# -gt 0 ]; do
@@ -127,7 +125,7 @@ parse_pull() {
         eval 'set -- "${OPTARG%%\=*}" "${OPTARG#*\=}"' ${1+'"$@"'}
         ;;
       --no-*|--without-*) unset OPTARG ;;
-      -[brdf]?*) OPTARG=$1; shift
+      -[brf]?*) OPTARG=$1; shift
         eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
         ;;
       -[vsh]?*) OPTARG=$1; shift
@@ -150,11 +148,6 @@ parse_pull() {
         OPTARG=$2
         REPOSITORY="$OPTARG"
         shift ;;
-      '-d'|'--directory')
-        [ $# -le 1 ] && set "required" "$1" && break
-        OPTARG=$2
-        DIRECTORY="$OPTARG"
-        shift ;;
       '-f'|'--filter')
         [ $# -le 1 ] && set "required" "$1" && break
         OPTARG=$2
@@ -176,13 +169,13 @@ parse_pull() {
       --)
         shift
         while [ $# -gt 0 ]; do
-          REST="${REST} \"\${$(($OPTIND-$#))}\""
+          PULL_REST="${PULL_REST} \"\${$(($OPTIND-$#))}\""
           shift
         done
         break ;;
       [-]?*) set "unknown" "$1"; break ;;
       *)
-        REST="${REST} \"\${$(($OPTIND-$#))}\""
+        PULL_REST="${PULL_REST} \"\${$(($OPTIND-$#))}\""
     esac
     shift
   done
@@ -200,12 +193,11 @@ parse_pull() {
 }
 usage_pull() {
 cat<<'GETOPTIONSHERE'
-Usage: atlas pull [options...] [arguments...]
+Usage: atlas pull [options...] [directory mappings...]
 Options:
       --config CONFIG         path to alternative atlas.yaml configuration file
   -b, --branch BRANCH         A branch of translation files
   -r, --repository REPOSITORY The repository containing translation files
-  -d, --directory DIRECTORY   Directory (name of the repository) containing translations to be downloaded
   -f, --filter FILTER         List of patterns to select which files and sub-directories to checkout.
   -v, --verbose               verbose output to terminal
   -s, --silent                no output to terminal
@@ -256,9 +248,10 @@ set_pull_params() {
   fi
 
   # Override vars based on args
-  if [ "$DIRECTORY" ];
+  if [ $# -gt 0 ];
   then
-      pull_directory=$DIRECTORY
+    # Due to sh/dash compatibility, arrays are not supported, therefore directories with spaces aren't supported.
+    pull_directory="$*"
   fi
 
   if [ "$REPOSITORY" ];
@@ -279,6 +272,12 @@ set_pull_params() {
   pull_filter="$(echo "$pull_filter" | tr ',' ' ')"  # Accept comma and/or space separated directories list
 }
 
+contains_substring() {
+  # Checks if $1 string contains $2.
+  printf '%s' "$1" | grep --fixed-strings --silent -e "$2"
+  return $?
+}
+
 display_pull_params() {
   # Output configured vars to user
   echo "Pulling translation files"
@@ -289,6 +288,14 @@ display_pull_params() {
 }
 
 pull_translations() {
+  if [ -z "$pull_directory" ];
+  then
+      echo "Missing positional argument:" >&2
+      echo "  At least one DIRECTORY map is required as a positional argument:" >&2
+      echo "  $ atlas pull DIRECTORY_FROM1:DIRECTORY_TO1 DIRECTORY_FROM2:DIRECTORY_TO2 ..." >&2
+      return 1
+  fi
+
   if [ -z "$SILENT" ];
   then
     echo "Creating a temporary Git repository to pull translations into \"./translations_TEMP\"..."
@@ -323,29 +330,40 @@ pull_translations() {
   then
     echo "Done."
 
-    echo "Pulling translations into \"./translations_TEMP/$pull_directory\"..."
+    echo "Setting git sparse-checkout rules..."
   fi
 
-  # If a directory is specified, configure git for a sparse checkout
-  if [ "$pull_directory" ];
-  then
-    # Reset git sparse-checkout list of include/exclude files
-    # Tells sparse checkout to ignore all files, except when otherwise noted
-    # See https://www.git-scm.com/docs/git-sparse-checkout for detailed implementation
-    git sparse-checkout set "!*"
+  # Reset git sparse-checkout list of include/exclude files
+  # Tells sparse checkout to ignore all files, except when otherwise noted
+  # See https://www.git-scm.com/docs/git-sparse-checkout for detailed implementation
+  git sparse-checkout set "!*"
+
+  # Set sparse-checkout rules
+  for directory_from_to in $pull_directory;
+  do
+    directory_from=$(echo "${directory_from_to}" | cut -f1 -d ':')
 
     if [ "$pull_filter" ];
     then
-        for one_filter in $pull_filter;
-        do
-            # Include directories that matches the language pattern e.g. `/ar/`
-            git sparse-checkout add "$pull_directory/**/${one_filter}/**"
-            # Include files that matches the language pattern e.g. `ar.*`
-            git sparse-checkout add "$pull_directory/**/${one_filter}.*"
-        done
+      for one_filter in $pull_filter;
+      do
+        # Include directories that matches the language pattern e.g. `/ar/`
+        git sparse-checkout add "$directory_from/**/${one_filter}/**"
+        # Include files that matches the language pattern e.g. `ar.*`
+        git sparse-checkout add "$directory_from/**/${one_filter}.*"
+      done
     else
-        git sparse-checkout add "$pull_directory/"
+      # Include all files within provided DIRECTORY if no filter is specified.
+      git sparse-checkout add "$directory_from/**"
     fi
+  done
+
+  # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
+  if [ -z "$SILENT" ];
+  then
+    echo "Done."
+
+    echo "Pulling translation files from the repository..."
   fi
 
   # Retrieve translation files from the repo
@@ -358,20 +376,29 @@ pull_translations() {
   cd ..
 
   # finished "Pulling translations into <temp dir>..." step
-  if [ -z "$SILENT" ];
-  then
-    echo "Done."
-
-    echo "Copying translations from \"./translations_TEMP/$pull_directory\" to \"./$pull_directory\"..."
-  fi
 
   # Copy translation files out of the temp dir
-  if [ "$pull_directory" ];
-  then
-    cp -r translations_TEMP/"$pull_directory"/* ./
-  else
-    cp -r translations_TEMP/* ./
-  fi
+  for directory_from_to in $pull_directory;
+  do
+    directory_from="$(echo "${directory_from_to}" | cut -f1 -d ':')"
+    directory_from="./translations_TEMP/${directory_from}"
+
+    # If no colon is provided then directory_to=. (aka working directory)
+    if contains_substring "$directory_from_to" ":";
+    then
+      directory_to="$(echo "${directory_from_to}" | cut -f2 -d ':')"
+    else
+      directory_to=.
+    fi
+
+    mkdir -p "$directory_to"
+    if [ -z "$SILENT" ];
+    then
+      echo "Done."
+      echo "Copying translations from \"${directory_from}\" to \"./${directory_to}\"..."
+    fi
+    cp -r "${directory_from}"/* "${directory_to}"/ || exit 1
+  done
 
   # finished "Copying translations from <temp dir> to <dest dir>..." step
   if [ -z "$SILENT" ];
@@ -407,17 +434,17 @@ if [ $# -gt 0 ]; then
 	case $cmd in
 		pull)
 			parse_pull "$@"
-      set_pull_params
-
-      if [ -z "$SILENT" ];
-      then
-        display_pull_params
-      fi
-      # allow mocking pull_translations
-      __ begin_pull_translations_mock __
-      pull_translations
-      __ end_pull_translations_mock __
-      ;;
+            eval "set -- $PULL_REST"
+            set_pull_params "$@" # Make the arguments available to `set_pull_params`
+            if [ -z "$SILENT" ];
+            then
+              display_pull_params
+            fi
+            # allow mocking pull_translations
+            __ begin_pull_translations_mock __
+            pull_translations || exit 1
+            __ end_pull_translations_mock __
+            ;;
 		--) # no subcommand, arguments only
 	esac
 fi

--- a/spec/config_spec.sh
+++ b/spec/config_spec.sh
@@ -98,10 +98,10 @@ Describe 'Test full flags'
   }
 
   It 'correctly reads full flag params'
-    When run source ./atlas pull --directory full_flag_directory --repository full_flag_repository --branch full_flag_branch --filter ar,es_419
+    When run source ./atlas pull --repository full_flag_repository --branch full_flag_branch --filter ar,es_419 positional_arg_directory:to_dir
     The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
-    The line 2 of output should equal ' - directory: full_flag_directory'
+    The line 2 of output should equal ' - directory: positional_arg_directory:to_dir'
     The line 3 of output should equal ' - repository: full_flag_repository'
     The line 4 of output should equal ' - branch: full_flag_branch'
     The line 5 of output should equal ' - filter: ar es_419'
@@ -120,13 +120,35 @@ Describe 'Test short flags'
   }
 
   It 'correctly reads short flag params'
-    When run source ./atlas pull -d short_flag_directory -r short_flag_repository -b short_flag_branch -f 'ar es_419'
+    When run source ./atlas pull -r short_flag_repository -b short_flag_branch -f 'ar es_419' positional_arg_directory:mapped_to_dir
     The lines of output should equal 5
     The line 1 of output should equal 'Pulling translation files'
-    The line 2 of output should equal ' - directory: short_flag_directory'
+    The line 2 of output should equal ' - directory: positional_arg_directory:mapped_to_dir'
     The line 3 of output should equal ' - repository: short_flag_repository'
     The line 4 of output should equal ' - branch: short_flag_branch'
     The line 5 of output should equal ' - filter: ar es_419'
+    The variable PULL_TRANSLATIONS_CALLED should equal true
+  End
+End
+
+
+Describe 'Test short flags'
+  # mock pull translations
+  Intercept begin_pull_translations_mock
+  __begin_pull_translations_mock__() {
+    pull_translations() {
+      PULL_TRANSLATIONS_CALLED=true
+      %preserve PULL_TRANSLATIONS_CALLED
+    }
+  }
+
+  It 'correctly reads multiple directories and separate them in spaces'
+    When run source ./atlas pull -r short_flag_repository  \
+                            orange_dir:foo_local_dir \
+                            blue_dir:bazz_local_dir
+    The lines of output should equal 5
+    The line 1 of output should equal 'Pulling translation files'
+    The line 2 of output should equal ' - directory: orange_dir:foo_local_dir blue_dir:bazz_local_dir'
     The variable PULL_TRANSLATIONS_CALLED should equal true
   End
 End

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -1,4 +1,4 @@
-Describe 'Pull without directory param'
+Describe 'Pull without directory mapping param'
   Include ./atlas
 
   git() {
@@ -12,23 +12,12 @@ Describe 'Pull without directory param'
   setup() { pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
   BeforeEach 'setup'
 
-  It 'calls everything properly'
+  It 'Fails and require a directory mapping positional parameter'
     When call pull_translations
-    The lines of output should equal 14
-    The line 1 of output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...'
-    The line 2 of output should equal 'git init -b main'
-    The line 3 of output should equal 'git remote add -f origin https://github.com/pull_repository.git'
-    The line 4 of output should equal 'Done.'
-    The line 5 of output should equal 'Pulling translations into "./translations_TEMP/"...'
-    The line 6 of output should equal 'git pull origin pull_branch'
-    The line 7 of output should equal 'Done.'
-    The line 8 of output should equal 'Copying translations from "./translations_TEMP/" to "./"...'
-    The line 9 of output should equal 'cp -r translations_TEMP/* ./'
-    The line 10 of output should equal 'Done.'
-    The line 11 of output should equal 'Removing temporary directory...'
-    The line 12 of output should equal 'Done.'
-    The line 13 of output should equal ''
-    The line 14 of output should equal 'Translations pulled successfully!'
+    The status should be failure
+    The error should equal 'Missing positional argument:
+  At least one DIRECTORY map is required as a positional argument:
+  $ atlas pull DIRECTORY_FROM1:DIRECTORY_TO1 DIRECTORY_FROM2:DIRECTORY_TO2 ...'
 
   End
 End
@@ -45,28 +34,30 @@ Describe 'Pull with directory param'
   }
 
 
-  setup() { pull_directory="pull_directory" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
+  setup() { pull_directory="pull_directory:local_dir" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
   BeforeEach 'setup'
 
   It 'calls everything properly'
     When call pull_translations
-    The lines of output should equal 16
-    The line 1 of output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...'
-    The line 2 of output should equal 'git init -b main'
-    The line 3 of output should equal 'git remote add -f origin https://github.com/pull_repository.git'
-    The line 4 of output should equal 'Done.'
-    The line 5 of output should equal 'Pulling translations into "./translations_TEMP/pull_directory"...'
-    The line 6 of output should equal 'git sparse-checkout set !*'
-    The line 7 of output should equal 'git sparse-checkout add pull_directory/'
-    The line 8 of output should equal 'git pull origin pull_branch'
-    The line 9 of output should equal 'Done.'
-    The line 10 of output should equal 'Copying translations from "./translations_TEMP/pull_directory" to "./pull_directory"...'
-    The line 11 of output should equal 'cp -r translations_TEMP/pull_directory/* ./'
-    The line 12 of output should equal 'Done.'
-    The line 13 of output should equal 'Removing temporary directory...'
-    The line 14 of output should equal 'Done.'
-    The line 15 of output should equal ''
-    The line 16 of output should equal 'Translations pulled successfully!'
+    The lines of output should equal 18
+    The output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...
+git init -b main
+git remote add -f origin https://github.com/pull_repository.git
+Done.
+Setting git sparse-checkout rules...
+git sparse-checkout set !*
+git sparse-checkout add pull_directory/**
+Done.
+Pulling translation files from the repository...
+git pull origin pull_branch
+Done.
+Copying translations from "./translations_TEMP/pull_directory" to "./local_dir"...
+cp -r ./translations_TEMP/pull_directory/* local_dir/
+Done.
+Removing temporary directory...
+Done.
+
+Translations pulled successfully!'
   End
 End
 

--- a/spec/verbosity_spec.sh
+++ b/spec/verbosity_spec.sh
@@ -35,9 +35,9 @@ Describe 'Test default verbosity'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
-    When run source ./atlas pull
-    The lines of output should equal 15
-    The line 15 of output should equal 'Translations pulled successfully!'
+    When run source ./atlas pull dir_from:dir_to
+    The lines of output should equal 17
+    The line 17 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable GIT_CALLED_VERBOSELY should equal false
@@ -51,14 +51,18 @@ Describe 'Test silent flag'
   Intercept begin_pull_translations_mock
   __begin_pull_translations_mock__() {
     git() {
-      if [ "$quiet" ];
+      # Don't check `git sparse-checkout` for `--quiet` because it prints no output.
+      if [ "$1" != "sparse-checkout" ];
       then
-        GIT_CALLED_QUIETLY=true
-      else
-        GIT_CALLED_NOT_QUIETLY=true
+        if [ "$quiet" ];
+        then
+          GIT_CALLED_QUIETLY=true
+        else
+          GIT_CALLED_NOT_QUIETLY=true
+        fi
+        %preserve GIT_CALLED_QUIETLY
+        %preserve GIT_CALLED_NOT_QUIETLY
       fi
-      %preserve GIT_CALLED_QUIETLY
-      %preserve GIT_CALLED_NOT_QUIETLY
     }
 
     cp() {
@@ -71,8 +75,9 @@ Describe 'Test silent flag'
     GIT_CALLED_QUIETLY=false
     GIT_CALLED_NOT_QUIETLY=false
     CP_CALLED=false
-    When run source ./atlas pull --silent
+    When run source ./atlas pull --silent dir_from:dir_to
     The lines of output should equal 0
+    The output should equal ""
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable CP_CALLED should equal true
@@ -82,8 +87,9 @@ Describe 'Test silent flag'
     GIT_CALLED_QUIETLY=false
     GIT_CALLED_NOT_QUIETLY=false
     CP_CALLED=false
-    When run source ./atlas pull -s
+    When run source ./atlas pull -s dir_from:dir_to
     The lines of output should equal 0
+    The output should equal ""
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable CP_CALLED should equal true
@@ -127,9 +133,9 @@ Describe 'Test verbose flag'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
-    When run source ./atlas pull --verbose
-    The lines of output should equal 15
-    The line 15 of output should equal 'Translations pulled successfully!'
+    When run source ./atlas pull --verbose dir_from:dir_to
+    The lines of output should equal 17
+    The line 17 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal false
     The variable GIT_CALLED_NOT_QUIETLY should equal true
     The variable GIT_CALLED_VERBOSELY should equal true
@@ -143,9 +149,9 @@ Describe 'Test verbose flag'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
-    When run source ./atlas pull -v
-    The lines of output should equal 15
-    The line 15 of output should equal 'Translations pulled successfully!'
+    When run source ./atlas pull -v dir_from:dir_to
+    The lines of output should equal 17
+    The line 17 of output should equal 'Translations pulled successfully!'
     The variable GIT_CALLED_QUIETLY should equal false
     The variable GIT_CALLED_NOT_QUIETLY should equal true
     The variable GIT_CALLED_VERBOSELY should equal true


### PR DESCRIPTION
## Description

Remove the `--directory` argument in favor of the positional arguments `DIRECTORY ...` to allow multiple directories to be specified in a single step. This is useful for pulling a huge batch of XBlocks into edX Platform or components in MFEs in a single `checkout` operation.


Breaking Changes and Developer Experience
----------------

One of the primary goals of the project is to **avoid breaking changes**. However, this pull request **breaks** compatibility with current (if any) usage of atlas due to the change from `--directory` argument to `DIRECTORY...` positional argument.

The main driver behind this change is to allow breaking the command into multiple lines, in which the `--directory` argument wouldn't support:

```
$ atlas pull translations/frontend-app-learning/:learning-mfe \
            translations/frontend-component-header/src/i18n/messages:frontend-component-header
```

### Testing
 - [ ] Fix all tests after the initial review is passed
 - [ ] Add additional tests for new use cases

## Argument description

`DIRECTORY...` represents one or more directory map pair separated by a colon (:) e.g. `FROM_DIR:TO_DIR`:

- The first directory (FROM_DIR) represents a directory in the git repository.
- The second directory (TO_DIR) represents a local directory to copy files to.
- At least one directory pair is required.
- This syntax is inspired by `docker --volume from_dir:to_dir` mounting syntax.
  
## Design
In order for this to work, an extensive "matrix" of `git sparse-checkout` rules are added to filter for each `DIRECTORY` and `--filter`:

```
# Include directories that matches the language pattern e.g. `/ar/`
git sparse-checkout add "$directory_from/**/${one_filter}/**"
# Include files that matches the language pattern e.g. `ar.*`
git sparse-checkout add "$directory_from/**/${one_filter}.*"
```

For example, two directories and three languages would result into 12 rules. 

```
 1. translations/frontend-app-learning/src/i18n/messages/**/fr_CA/**
 2. translations/frontend-app-learning/src/i18n/messages/**/fr_CA.*
 3. translations/frontend-app-learning/src/i18n/messages/**/ar/**
 4. translations/frontend-app-learning/src/i18n/messages/**/ar.*
 5. translations/frontend-app-learning/src/i18n/messages/**/es_419/**
 6. translations/frontend-app-learning/src/i18n/messages/**/es_419.*
 7. translations/frontend-component-footer/src/i18n/messages/**/fr_CA/**
 8. translations/frontend-component-footer/src/i18n/messages/**/fr_CA.*
 9. translations/frontend-component-footer/src/i18n/messages/**/ar/**
10. translations/frontend-component-footer/src/i18n/messages/**/ar.*
11. translations/frontend-component-footer/src/i18n/messages/**/es_419/**
12. translations/frontend-component-footer/src/i18n/messages/**/es_419.*
```

## Example call

```
$ cd frontend-app-learning/src/i18n/messages
$ atlas pull --filter=fr_CA,ar,es_419 \
            translations/frontend-app-learning/src/i18n/messages:frontend-app-learning \
            translations/frontend-component-header/src/i18n/messages:frontend-component-header
```

Will result in the following tree:
```
├── frontend-app-learning
│   ├── ar.json
│   ├── es_419.json
│   └── fr_CA.json
└── frontend-component-header
    ├── ar.json
    ├── es_419.json
    └── fr_CA.json
```
References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time
