### PR TITLE
perf: 120x faster clone with real-world performance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: gengetoptions
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
-	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort	
+	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 # requires getoptions to be installed
 # installing getoptions locally: https://github.com/ko1nksm/getoptions/#installation
@@ -12,5 +12,12 @@ gengetoptions: ## use getoptions to generate argument parsing
 # requires shellspec to be installed
 # installing shellspec locally: https://github.com/shellspec/shellspec/#installation
 # note: the CI uses the latest stable version available in brew: `brew tap shellspec/shellspec`, `brew install shellspec`
-test: ## automated testing using shellspec
+
+unit_tests: ## automated testing using shellspec: fast unit tests without external dependency
+	shellspec $(shell find spec/ -type f ! -name pull_performance_spec.sh ! -name spec_helper.sh)
+
+performance_tests:  ## automated testing using shellspec: performance integration tests pulling from GitHub.com/openedx
+	shellspec spec/pull_performance_spec.sh
+
+test: ## automated testing using shellspec: run all tests
 	shellspec

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,9 @@ Running Automated Tests Locally
 
 **Run**
 
-``make test``
+  - ``make test``:  run all tests
+  - ``make performance_tests``:  run performance tests which pulls from GitHub.com/openedx
+  - ``make unit_tests``:  run fast unit tests without external dependency
 
 Documentation
 -------------

--- a/atlas
+++ b/atlas
@@ -301,10 +301,6 @@ pull_translations() {
     echo "Creating a temporary Git repository to pull translations into \"./translations_TEMP\"..."
   fi
 
-  # Create temp dir for translations
-  mkdir translations_TEMP
-  cd translations_TEMP || exit
-
   # use git in quiet mode when verbose isn't set
   if [ "$VERBOSE" ];
   then
@@ -313,17 +309,19 @@ pull_translations() {
     quiet="--quiet"
   fi
 
-  # Initialize git repo and add remote
-  git init $quiet -b main
-  remote_url="https://github.com/$pull_repository.git"
-  if [ "$quiet" ];
+  # use git in quiet mode when verbose isn't set
+  if [ "$pull_branch" ];
   then
-    # git remote doesn't support `--quiet`
-    # redirect git output to /dev/null if we aren't in verbose mode
-    git remote add -f origin "$remote_url" &> /dev/null
+    pull_branch_argument="--branch=${pull_branch}"
   else
-    git remote add -f origin "$remote_url"
+    pull_branch_argument=""
   fi
+
+  # Creating a shallow clone of the repo without without pulling the files yet
+  # shellcheck disable=SC2086
+  git clone $quiet $pull_branch_argument --filter=blob:none --no-checkout --depth=1 \
+            "https://github.com/${pull_repository}.git" translations_TEMP || exit
+  cd translations_TEMP || exit
 
   # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
   if [ -z "$SILENT" ];
@@ -336,7 +334,7 @@ pull_translations() {
   # Reset git sparse-checkout list of include/exclude files
   # Tells sparse checkout to ignore all files, except when otherwise noted
   # See https://www.git-scm.com/docs/git-sparse-checkout for detailed implementation
-  git sparse-checkout set "!*"
+  git sparse-checkout set --no-cone "!*"
 
   # Set sparse-checkout rules
   for directory_from_to in $pull_directory;
@@ -367,7 +365,7 @@ pull_translations() {
   fi
 
   # Retrieve translation files from the repo
-  git pull $quiet origin "$pull_branch"
+  git checkout HEAD
 
   # Remove .git directory
   rm -rf .git

--- a/spec/pull_performance_spec.sh
+++ b/spec/pull_performance_spec.sh
@@ -1,0 +1,73 @@
+check_call_time() {
+  # Custom ShellSpec assert for call time.
+  local test_name="$1"
+  local test_start_time=$2
+  local max_allowed_sec=$3
+  local current_time=$(date +%s)
+  local test_elapsed_time=$(($current_time-$test_start_time))
+
+  if [ $test_elapsed_time -gt $max_allowed_sec ];
+  then
+    echo "'$test_name' test case took $test_elapsed_time seconds which exceeded the allowed max of $max_allowed_sec seconds" >&2
+    exit 1
+  fi
+}
+
+
+Describe 'Pull performance on edX Platform Arabic translations'
+  Intercept begin_pull_translations_mock
+  __begin_pull_translations_mock__() {
+    cp() {
+      echo /usr/bin/env cp $@  # Run cp, but intercept with `find`
+
+      # The output is sorted to ensure cross-platform consistent output
+      find translations_TEMP/conf -type f | LC_ALL=C sort -n -k1,1 >&2 # Allow checking tree content.
+    }
+  }
+
+  setup() {
+    TEST_START_TIME=$(date +%s)  # Time the bash script
+    PREVIOUS_PWD="$PWD";
+    cd "$(mktemp -d)" || exit 1  # Run in a temp. directory
+  }
+  tearDown() {
+    cd "$PREVIOUS_PWD" || exit 1
+  }
+  BeforeEach 'setup'
+  AfterEach 'tearDown'
+
+  It 'calls everything properly'
+    TEST_START_TIME=$(date +%s)  # Time the bash script
+    When run source $PREVIOUS_PWD/atlas pull -r openedx/edx-platform -b open-release/nutmeg.1 -f ar,fr conf/locale:messages
+    Assert check_call_time "Pull edX Platform" $TEST_START_TIME 10  # Allow a maximum of 10 seconds
+
+    The output should equal 'Pulling translation files
+ - directory: conf/locale:messages
+ - repository: openedx/edx-platform
+ - branch: open-release/nutmeg.1
+ - filter: ar fr
+Creating a temporary Git repository to pull translations into "./translations_TEMP"...
+Done.
+Setting git sparse-checkout rules...
+Done.
+Pulling translation files from the repository...
+Done.
+Copying translations from "./translations_TEMP/conf/locale" to "./messages"...
+/usr/bin/env cp -r ./translations_TEMP/conf/locale/ar ./translations_TEMP/conf/locale/fr messages/
+Done.
+Removing temporary directory...
+Done.
+
+Translations pulled successfully!'
+
+    # Checks the results of `find`
+    The error should equal "translations_TEMP/conf/locale/ar/LC_MESSAGES/django.mo
+translations_TEMP/conf/locale/ar/LC_MESSAGES/django.po
+translations_TEMP/conf/locale/ar/LC_MESSAGES/djangojs.mo
+translations_TEMP/conf/locale/ar/LC_MESSAGES/djangojs.po
+translations_TEMP/conf/locale/fr/LC_MESSAGES/django.mo
+translations_TEMP/conf/locale/fr/LC_MESSAGES/django.po
+translations_TEMP/conf/locale/fr/LC_MESSAGES/djangojs.mo
+translations_TEMP/conf/locale/fr/LC_MESSAGES/djangojs.po"
+  End
+End

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -33,28 +33,37 @@ Describe 'Pull with directory param'
     echo "cp $@"
   }
 
+  cd() {
+      echo "cd $@"
+  }
+
+  rm() {
+      echo "rm $@"
+  }
 
   setup() { pull_directory="pull_directory:local_dir" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
   BeforeEach 'setup'
 
   It 'calls everything properly'
     When call pull_translations
-    The lines of output should equal 18
     The output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...
-git init -b main
-git remote add -f origin https://github.com/pull_repository.git
+git clone --branch=pull_branch --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
+cd translations_TEMP
 Done.
 Setting git sparse-checkout rules...
-git sparse-checkout set !*
+git sparse-checkout set --no-cone !*
 git sparse-checkout add pull_directory/**
 Done.
 Pulling translation files from the repository...
-git pull origin pull_branch
+git checkout HEAD
+rm -rf .git
+cd ..
 Done.
 Copying translations from "./translations_TEMP/pull_directory" to "./local_dir"...
 cp -r ./translations_TEMP/pull_directory/* local_dir/
 Done.
 Removing temporary directory...
+rm -rf translations_TEMP
 Done.
 
 Translations pulled successfully!'
@@ -73,6 +82,13 @@ Describe 'Pull filters'
     true
   }
 
+  cd() {
+      echo "cd $@"
+  }
+
+  rm() {
+    true # Omit output
+  }
 
   setup() {
       pull_directory="pull_directory"
@@ -86,16 +102,16 @@ Describe 'Pull filters'
 
   It 'sets correct sparse-checkout rules'
     When call pull_translations
-    The lines of output should equal 10
-    The output should equal 'git init -b main
-git remote add -f origin https://github.com/pull_repository.git
-git sparse-checkout set !*
+    The output should equal 'git clone --branch=pull_branch --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
+cd translations_TEMP
+git sparse-checkout set --no-cone !*
 git sparse-checkout add pull_directory/**/ar/**
 git sparse-checkout add pull_directory/**/ar.*
 git sparse-checkout add pull_directory/**/es_419/**
 git sparse-checkout add pull_directory/**/es_419.*
 git sparse-checkout add pull_directory/**/fr_CA/**
 git sparse-checkout add pull_directory/**/fr_CA.*
-git pull origin pull_branch'
+git checkout HEAD
+cd ..'
   End
 End

--- a/spec/verbosity_spec.sh
+++ b/spec/verbosity_spec.sh
@@ -27,6 +27,16 @@ Describe 'Test default verbosity'
       CP_CALLED=true
       %preserve CP_CALLED
     }
+
+    cd() {
+      CD_CALLED=true
+      %preserve CD_CALLED
+    }
+
+    rm() {
+      RM_CALLED=true
+      %preserve RM_CALLED
+    }
   }
 
   It 'pulls translations with user friendly output'
@@ -35,6 +45,8 @@ Describe 'Test default verbosity'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
+    CD_CALLED=false
+    RM_CALLED=false
     When run source ./atlas pull dir_from:dir_to
     The lines of output should equal 17
     The line 17 of output should equal 'Translations pulled successfully!'
@@ -43,6 +55,8 @@ Describe 'Test default verbosity'
     The variable GIT_CALLED_VERBOSELY should equal false
     The variable GIT_CALLED_NOT_VERBOSELY should equal true
     The variable CP_CALLED should equal true
+    The variable CD_CALLED should equal true
+    The variable RM_CALLED should equal true
   End
 End
 
@@ -69,30 +83,48 @@ Describe 'Test silent flag'
       CP_CALLED=true
       %preserve CP_CALLED
     }
+
+    cd() {
+      CD_CALLED=true
+      %preserve CD_CALLED
+    }
+
+    rm() {
+      RM_CALLED=true
+      %preserve RM_CALLED
+    }
   }
 
   It 'pulls translations with no output (full flag)'
     GIT_CALLED_QUIETLY=false
     GIT_CALLED_NOT_QUIETLY=false
     CP_CALLED=false
+    CD_CALLED=false
+    RM_CALLED=false
     When run source ./atlas pull --silent dir_from:dir_to
     The lines of output should equal 0
     The output should equal ""
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable CP_CALLED should equal true
+    The variable CD_CALLED should equal true
+    The variable RM_CALLED should equal true
   End
 
   It 'pulls translations with no output (short flag)'
     GIT_CALLED_QUIETLY=false
     GIT_CALLED_NOT_QUIETLY=false
     CP_CALLED=false
+    CD_CALLED=false
+    RM_CALLED=false
     When run source ./atlas pull -s dir_from:dir_to
     The lines of output should equal 0
     The output should equal ""
     The variable GIT_CALLED_QUIETLY should equal true
     The variable GIT_CALLED_NOT_QUIETLY should equal false
     The variable CP_CALLED should equal true
+    The variable CD_CALLED should equal true
+    The variable RM_CALLED should equal true
   End
 End
 
@@ -125,6 +157,16 @@ Describe 'Test verbose flag'
       CP_CALLED=true
       %preserve CP_CALLED
     }
+
+    cd() {
+      CD_CALLED=true
+      %preserve CD_CALLED
+    }
+
+    rm() {
+      RM_CALLED=true
+      %preserve RM_CALLED
+    }
   }
 
   It 'pulls translations with verbose output (full flag)'
@@ -133,6 +175,8 @@ Describe 'Test verbose flag'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
+    CD_CALLED=false
+    RM_CALLED=false
     When run source ./atlas pull --verbose dir_from:dir_to
     The lines of output should equal 17
     The line 17 of output should equal 'Translations pulled successfully!'
@@ -141,6 +185,8 @@ Describe 'Test verbose flag'
     The variable GIT_CALLED_VERBOSELY should equal true
     The variable GIT_CALLED_NOT_VERBOSELY should equal false
     The variable CP_CALLED should equal true
+    The variable CD_CALLED should equal true
+    The variable RM_CALLED should equal true
   End
 
   It 'pulls translations with verbose output (short flag)'
@@ -149,6 +195,8 @@ Describe 'Test verbose flag'
     GIT_CALLED_VERBOSELY=false
     GIT_CALLED_NOT_VERBOSELY=false
     CP_CALLED=false
+    CD_CALLED=false
+    RM_CALLED=false
     When run source ./atlas pull -v dir_from:dir_to
     The lines of output should equal 17
     The line 17 of output should equal 'Translations pulled successfully!'
@@ -157,5 +205,7 @@ Describe 'Test verbose flag'
     The variable GIT_CALLED_VERBOSELY should equal true
     The variable GIT_CALLED_NOT_VERBOSELY should equal false
     The variable CP_CALLED should equal true
+    The variable CD_CALLED should equal true
+    The variable RM_CALLED should equal true
   End
 End


### PR DESCRIPTION
## Description
`git add remote --fetch origin` is very slow for any medium to large repository. With this fix, the performance is hugely improved by fetching only after sparse-checkout rules are set, therefore making checkout almost instant.

Additionally, the `git` steps are simplified into fewer steps.

## Testing

 - [x] Added an integration (real) test scenario with timing constraint of 10 seconds for the `edx-platform:conf/locale` directory
 - [x] Fix existing broken test cases after initial review

## Test results
The `new_` implementation is waaaay faster!

| Test | Old | New  |
|--------|--------|--------|
| Clone edx-ios-app Source directory | 1m 57s | 1s |
| Clone edx-platform | Too much | 2s |

<details><summary>Performance testing code</summary>
<p>



```shell
new_clone_ios() {
  cd /tmp
  rm -rf /tmp/atlas-repo
  mkdir -p /tmp/atlas-repo
  cd /tmp/atlas-repo
  git clone --filter=blob:none --no-checkout --depth=1 --branch=master "https://github.com/openedx/edx-app-ios.git" atlas-repo
  cd atlas-repo
  git sparse-checkout set '!*'
  git sparse-checkout add 'Source/**'
  git checkout HEAD
  tree
}

old_clone_ios() {
  cd /tmp
  rm -rf /tmp/atlas-repo
  mkdir -p /tmp/atlas-repo
  cd /tmp/atlas-repo
  git init -b master
  git remote add -f origin "https://github.com/openedx/edx-app-ios.git"
  git sparse-checkout set '!*'
  git sparse-checkout add 'Source/**'
  git pull origin master
  tree
}

new_clone_edx_platform() {
  cd /tmp
  rm -rf /tmp/atlas-repo
  mkdir -p /tmp/atlas-repo
  cd /tmp/atlas-repo
  git clone --filter=blob:none --no-checkout --depth=1 --branch=master "https://github.com/openedx/edx-platform.git" atlas-repo
  cd atlas-repo
  git sparse-checkout set '!*'
  git sparse-checkout add 'conf/locale/ar**'
  git checkout HEAD
  tree
}

old_clone_edx_platform() {
  cd /tmp
  rm -rf /tmp/atlas-repo
  mkdir -p /tmp/atlas-repo
  cd /tmp/atlas-repo
  git init -b master
  git remote add -f origin "https://github.com/openedx/edx-platform.git"
  git sparse-checkout set '!*'
  git sparse-checkout add 'conf/locale/ar**'
  git pull origin master
  tree
}


##################
time new_clone_ios
# real	0m1.147s
# user	0m0.064s
# sys	0m0.016s

##################
time old_clone_ios
# real	1m57.448s
# user	0m35.059s
# sys	0m9.742s

###################
time new_clone_edx_platform
# real	0m2.600s
# user	0m0.237s
# sys	0m0.079s

##################
time old_clone_edx_platform
# real infinity!
# user infinity!
# sys infinity!

```

</p>
</details> 

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes.
