### PR TITLE
test: add tests for multiple directories in pull_spec.sh

### DIFF
--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -41,10 +41,19 @@ Describe 'Pull with directory param'
       echo "rm $@"
   }
 
-  setup() { pull_directory="pull_directory:local_dir" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
+  mkdir() {
+    echo "mkdir $@"
+  }
+
+  cd() {
+    echo "cd $@"
+  }
+
+
+  setup() { pull_directory="pull_directory:local_dir pull_dir2:new/local_dir2" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
   BeforeEach 'setup'
 
-  It 'calls everything properly'
+  It 'calls everything properly with multiple directories'
     When call pull_translations
     The output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...
 git clone --branch=pull_branch --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
@@ -53,14 +62,20 @@ Done.
 Setting git sparse-checkout rules...
 git sparse-checkout set --no-cone !*
 git sparse-checkout add pull_directory/**
+git sparse-checkout add pull_dir2/**
 Done.
 Pulling translation files from the repository...
 git checkout HEAD
 rm -rf .git
 cd ..
+mkdir -p local_dir
 Done.
 Copying translations from "./translations_TEMP/pull_directory" to "./local_dir"...
 cp -r ./translations_TEMP/pull_directory/* local_dir/
+mkdir -p new/local_dir2
+Done.
+Copying translations from "./translations_TEMP/pull_dir2" to "./new/local_dir2"...
+cp -r ./translations_TEMP/pull_dir2/* new/local_dir2/
 Done.
 Removing temporary directory...
 rm -rf translations_TEMP


### PR DESCRIPTION
Test cases was missing multiple directory tests, this commit adds them.

I was going to add them into #13 but it was merged very fast :).

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time