### PR TITLE
fix: log missing repo directories instead of exiting

### DIFF
--- a/atlas
+++ b/atlas
@@ -278,6 +278,13 @@ contains_substring() {
   return $?
 }
 
+directory_exists() {
+  # Checks if directory ($1) exists
+  # This is mainly used to be mocked in tests
+  test -d "$1"
+  return $?
+}
+
 display_pull_params() {
   # Output configured vars to user
   echo "Pulling translation files"
@@ -395,7 +402,16 @@ pull_translations() {
       echo "Done."
       echo "Copying translations from \"${directory_from}\" to \"./${directory_to}\"..."
     fi
-    cp -r "${directory_from}"/* "${directory_to}"/ || exit 1
+
+    if directory_exists "$directory_from";
+    then
+      cp -r "${directory_from}"/* "${directory_to}"/ || exit 1
+    else
+      if [ -z "$SILENT" ];
+      then
+        echo "Skipped copying \"${directory_from}\" because it was not found in the repository."
+      fi
+    fi
   done
 
   # finished "Copying translations from <temp dir> to <dest dir>..." step

--- a/spec/pull_performance_spec.sh
+++ b/spec/pull_performance_spec.sh
@@ -38,11 +38,11 @@ Describe 'Pull performance on edX Platform Arabic translations'
 
   It 'calls everything properly'
     TEST_START_TIME=$(date +%s)  # Time the bash script
-    When run source $PREVIOUS_PWD/atlas pull -r openedx/edx-platform -b open-release/nutmeg.1 -f ar,fr conf/locale:messages
+    When run source $PREVIOUS_PWD/atlas pull -r openedx/edx-platform -b open-release/nutmeg.1 -f ar,fr conf/locale:messages non-existent-dir:no-files-here
     Assert check_call_time "Pull edX Platform" $TEST_START_TIME 10  # Allow a maximum of 10 seconds
 
     The output should equal 'Pulling translation files
- - directory: conf/locale:messages
+ - directory: conf/locale:messages non-existent-dir:no-files-here
  - repository: openedx/edx-platform
  - branch: open-release/nutmeg.1
  - filter: ar fr
@@ -54,6 +54,9 @@ Pulling translation files from the repository...
 Done.
 Copying translations from "./translations_TEMP/conf/locale" to "./messages"...
 /usr/bin/env cp -r ./translations_TEMP/conf/locale/ar ./translations_TEMP/conf/locale/fr messages/
+Done.
+Copying translations from "./translations_TEMP/non-existent-dir" to "./no-files-here"...
+Skipped copying "./translations_TEMP/non-existent-dir" because it was not found in the repository.
 Done.
 Removing temporary directory...
 Done.

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -29,6 +29,15 @@ Describe 'Pull with directory param'
     echo "git $@"
   }
 
+  directory_exists() {
+    if [ "$1" = "./translations_TEMP/missing_pull_dir" ];
+    then
+      return 1 # Mock as if `missing_pull_dir` is not checkedout.
+    else
+      return 0 # Mock other directories to exists.
+    fi
+  }
+
   cp() {
     echo "cp $@"
   }
@@ -50,7 +59,12 @@ Describe 'Pull with directory param'
   }
 
 
-  setup() { pull_directory="pull_directory:local_dir pull_dir2:new/local_dir2" pull_repository="pull_repository" pull_branch="pull_branch"; VERBOSE=1; }
+  setup() {
+      pull_directory="pull_directory:local_dir pull_dir2:new/local_dir2 missing_pull_dir:local_dir3"
+      pull_repository="pull_repository"
+      pull_branch="pull_branch";
+      VERBOSE=1;
+  }
   BeforeEach 'setup'
 
   It 'calls everything properly with multiple directories'
@@ -63,6 +77,7 @@ Setting git sparse-checkout rules...
 git sparse-checkout set --no-cone !*
 git sparse-checkout add pull_directory/**
 git sparse-checkout add pull_dir2/**
+git sparse-checkout add missing_pull_dir/**
 Done.
 Pulling translation files from the repository...
 git checkout HEAD
@@ -76,6 +91,10 @@ mkdir -p new/local_dir2
 Done.
 Copying translations from "./translations_TEMP/pull_dir2" to "./new/local_dir2"...
 cp -r ./translations_TEMP/pull_dir2/* new/local_dir2/
+mkdir -p local_dir3
+Done.
+Copying translations from "./translations_TEMP/missing_pull_dir" to "./local_dir3"...
+Skipped copying "./translations_TEMP/missing_pull_dir" because it was not found in the repository.
 Done.
 Removing temporary directory...
 rm -rf translations_TEMP

--- a/spec/verbosity_spec.sh
+++ b/spec/verbosity_spec.sh
@@ -23,6 +23,10 @@ Describe 'Test default verbosity'
       %preserve GIT_CALLED_NOT_VERBOSELY
     }
 
+    directory_exists() {
+      true  # Mock directory checks so they're copied and `CP_CALLED` is set to true.
+    }
+
     cp() {
       CP_CALLED=true
       %preserve CP_CALLED
@@ -77,6 +81,10 @@ Describe 'Test silent flag'
         %preserve GIT_CALLED_QUIETLY
         %preserve GIT_CALLED_NOT_QUIETLY
       fi
+    }
+
+    directory_exists() {
+      true  # Mock directory checks so they're copied and `CP_CALLED` is set to true.
     }
 
     cp() {
@@ -151,6 +159,10 @@ Describe 'Test verbose flag'
       %preserve GIT_CALLED_NOT_QUIETLY
       %preserve GIT_CALLED_VERBOSELY
       %preserve GIT_CALLED_NOT_VERBOSELY
+    }
+
+    directory_exists() {
+      true  # Mock directory checks so they're copied and `CP_CALLED` is set to true.
     }
 
     cp() {


### PR DESCRIPTION
A missing directory happens due to many reasons including missing translations in the repository.

This can be painful to fix for maintainers, so `atlas` should recover from this error by skipping the missing directory, logging it and resuming the copying process.


### Testing
 - [x] Unit tests are added.
 - [x] The tests has sneaked into the performance test since it's the only integration test we have.

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time