### PR TITLE
feat: support git v2.25.1 using `sparse-checkout set` instead of `sparse-checkout add`

### DIFF
--- a/.github/workflows/git-tests.yml
+++ b/.github/workflows/git-tests.yml
@@ -1,0 +1,68 @@
+name: Git compatibility tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+
+jobs:
+  git-tests:
+    name: "${{ matrix.os }}-git-${{ matrix.git_version }}"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 8
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            git_version: default
+
+          - os: ubuntu-20.04
+            git_version: default
+
+          - os: ubuntu-22.04
+            git_version: 2.40.1
+
+          - os: ubuntu-22.04
+            git_version: 2.30.2
+
+          - os: ubuntu-20.04
+            git_version: 2.25.1
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: install shellcheck
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y shellcheck
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: install shellspec
+      run: |
+        brew tap shellspec/shellspec
+        brew install shellspec
+    - name: install getoptions
+      run: |
+        brew tap ko1nksm/getoptions
+        brew install getoptions
+
+    - name: install custom version of git
+      run: |
+        sudo apt install gettext libcurl4-openssl-dev libexpat1-dev libz-dev libssl-dev
+        wget --no-verbose https://mirrors.edge.kernel.org/pub/software/scm/git/git-${{ matrix.git_version }}.tar.gz
+        tar -xzf git-${{ matrix.git_version }}.tar.gz
+        cd git-${{ matrix.git_version }}
+        make configure
+        ./configure --prefix=/usr/local
+        make all
+        sudo make install
+      if: matrix.git_version != 'default'
+
+    - name: print git version
+      run: git --version
+
+    - name: run integration tests
+      run: make integration_tests

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,15 @@ gengetoptions: ## use getoptions to generate argument parsing
 # note: the CI uses the latest stable version available in brew: `brew tap shellspec/shellspec`, `brew install shellspec`
 
 unit_tests: ## automated testing using shellspec: fast unit tests without external dependency
-	shellspec $(shell find spec/ -type f ! -name pull_performance_spec.sh ! -name spec_helper.sh)
+	shellspec $(shell find spec/ -type f ! -name pull_performance_spec.sh ! -name spec_helper.sh ! -name integration_spec.sh)
 
 performance_tests:  ## automated testing using shellspec: performance integration tests pulling from GitHub.com/openedx
+        # This is a slow test that takes a minute or two to run and intended to measure performance
 	shellspec spec/pull_performance_spec.sh
+
+integration_tests: ## automated testing using shellspec: faster `git` integration tests with external dependency
+	# This test run in few seconds and intended to test `git` integration
+	shellspec spec/integration_spec.sh
 
 test: ## automated testing using shellspec: run all tests
 	shellspec

--- a/atlas
+++ b/atlas
@@ -413,7 +413,33 @@ display_pull_params() {
   echo " - filter: ${pull_filter:-Not Specified}"
 }
 
+check_git_version() {
+  MINIMUM_GIT_VERSION="2.25.0"  # The `git sparse-checkout` subcommand was introduced in 2.25.0
+  GIT_VERSION=$(git --version | grep 'git version' | sed -e 's/git version //g')
+
+  # Check if GIT_VERSION is a valid version number
+  if ! echo "$GIT_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,3}$';
+  then
+    echo "Unable to determine git version. Please ensure git is installed and available on your PATH."
+    return 1
+  fi
+
+  if [ "$(printf '%s\n' "$MINIMUM_GIT_VERSION" "$GIT_VERSION" | sort --version-sort | head -n1)" != "$MINIMUM_GIT_VERSION" ];
+  then
+    echo "Git version ${GIT_VERSION} is not supported. Please upgrade to ${MINIMUM_GIT_VERSION} or higher."
+    return 1
+  fi
+}
+
+git_sparse_checkout_set() {
+    # Call `git sparse-checkout set --no-cone` with the list of include/exclude files as arguments
+    # as a replacement of `sparse-checkout add` that isn't available in git 2.25.0
+    xargs git sparse-checkout set
+}
+
 pull_translations() {
+  check_git_version || return 1
+
   if [ -z "$pull_directory" ];
   then
       echo "Missing positional argument:" >&2
@@ -457,30 +483,32 @@ pull_translations() {
     echo "Setting git sparse-checkout rules..."
   fi
 
-  # Reset git sparse-checkout list of include/exclude files
+  # Set git sparse-checkout list of include/exclude files
   # Tells sparse checkout to ignore all files, except when otherwise noted
   # See https://www.git-scm.com/docs/git-sparse-checkout for detailed implementation
-  git sparse-checkout set --no-cone "!*"
+  git_sparse_checkout_rules="'--no-cone' '!*'"
 
-  # Set sparse-checkout rules
   for directory_from_to in $pull_directory;
   do
     directory_from=$(echo "${directory_from_to}" | cut -f1 -d ':')
+    directory_to=$(echo "${directory_from_to}" | cut -f2 -d ':')
 
     if [ "$pull_filter" ];
     then
       for one_filter in $pull_filter;
       do
         # Include directories that matches the language pattern e.g. `/ar/`
-        git sparse-checkout add "$directory_from/**/${one_filter}/**"
+        git_sparse_checkout_rules="${git_sparse_checkout_rules} '${directory_from}/**/${one_filter}/**'"
         # Include files that matches the language pattern e.g. `ar.*`
-        git sparse-checkout add "$directory_from/**/${one_filter}.*"
+        git_sparse_checkout_rules="${git_sparse_checkout_rules} '${directory_from}/**/${one_filter}.*'"
       done
     else
       # Include all files within provided DIRECTORY if no filter is specified.
-      git sparse-checkout add "$directory_from/**"
+      git_sparse_checkout_rules="${git_sparse_checkout_rules} '${directory_from}/**'"
     fi
   done
+
+  echo "$git_sparse_checkout_rules" | git_sparse_checkout_set
 
   # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
   if [ -z "$SILENT" ];

--- a/spec/integration_spec.sh
+++ b/spec/integration_spec.sh
@@ -1,0 +1,72 @@
+check_call_time() {
+  # Custom ShellSpec assert for call time.
+  local test_name="$1"
+  local test_start_time=$2
+  local max_allowed_sec=$3
+  local current_time=$(date +%s)
+  local test_elapsed_time=$(($current_time-$test_start_time))
+
+  if [ $test_elapsed_time -gt $max_allowed_sec ];
+  then
+    echo "'$test_name' test case took $test_elapsed_time seconds which exceeded the allowed max of $max_allowed_sec seconds" >&2
+    exit 1
+  fi
+}
+
+
+Describe 'Pull performance on edX Platform Arabic translations'
+  Intercept begin_pull_translations_mock
+  __begin_pull_translations_mock__() {
+    cp() {
+      echo /usr/bin/env cp $@  # Run cp, but intercept with `find`
+
+      # The output is sorted to ensure cross-platform consistent output
+      find translations_TEMP/drag_and_drop_v2/conf -type f | LC_ALL=C sort -n -k1,1 >&2 # Allow checking tree content.
+    }
+  }
+
+  setup() {
+    TEST_START_TIME=$(date +%s)  # Time the bash script
+    PREVIOUS_PWD="$PWD";
+    cd "$(mktemp -d)" || exit 1  # Run in a temp. directory
+  }
+  tearDown() {
+    cd "$PREVIOUS_PWD" || exit 1
+  }
+  BeforeEach 'setup'
+  AfterEach 'tearDown'
+
+  It 'calls everything properly'
+    TEST_START_TIME=$(date +%s)  # Time the bash script
+    When run source $PREVIOUS_PWD/atlas pull -r openedx/xblock-drag-and-drop-v2 -b v3.2.0 -f ar,fr drag_and_drop_v2:drag_and_drop_v2 non-existent-dir:no-files-here
+    Assert check_call_time "Pull xblock-drag-and-drop-v2" $TEST_START_TIME 60  # Allow a maximum of 60 seconds
+
+    The output should equal 'Pulling translation files
+ - directory: drag_and_drop_v2:drag_and_drop_v2 non-existent-dir:no-files-here
+ - repository: openedx/xblock-drag-and-drop-v2
+ - branch: v3.2.0
+ - filter: ar fr
+Creating a temporary Git repository to pull translations into "./translations_TEMP"...
+Done.
+Setting git sparse-checkout rules...
+Done.
+Pulling translation files from the repository...
+Done.
+Copying translations from "./translations_TEMP/drag_and_drop_v2" to "./drag_and_drop_v2"...
+/usr/bin/env cp -r ./translations_TEMP/drag_and_drop_v2/conf ./translations_TEMP/drag_and_drop_v2/public drag_and_drop_v2/
+Done.
+Copying translations from "./translations_TEMP/non-existent-dir" to "./no-files-here"...
+Skipped copying "./translations_TEMP/non-existent-dir" because it was not found in the repository.
+Done.
+Removing temporary directory...
+Done.
+
+Translations pulled successfully!'
+
+    # Checks the results of `find`
+    The error should equal "translations_TEMP/drag_and_drop_v2/conf/locale/ar/LC_MESSAGES/text.mo
+translations_TEMP/drag_and_drop_v2/conf/locale/ar/LC_MESSAGES/text.po
+translations_TEMP/drag_and_drop_v2/conf/locale/fr/LC_MESSAGES/text.mo
+translations_TEMP/drag_and_drop_v2/conf/locale/fr/LC_MESSAGES/text.po"
+  End
+End

--- a/spec/minimum_git_version_spec.sh
+++ b/spec/minimum_git_version_spec.sh
@@ -1,0 +1,106 @@
+# The `git sparse-checkout` subcommand was introduced in 2.25.0
+
+Describe 'Works on version 2.40.0'
+  git() {
+    echo "git version 2.40.0"
+  }
+
+  Include ./atlas
+
+  It 'Works'
+    When call check_git_version
+    The status should be success
+  End
+End
+
+
+Describe 'Works on version 2.25.0'
+  git() {
+    echo "git version 2.25.0"
+  }
+
+  Include ./atlas
+
+  It 'No off-by-one error'
+    When call check_git_version
+    The status should be success
+  End
+End
+
+
+Describe 'Require git version 2.25.0 at least'
+  git() {
+    echo "git version 2.20.1"
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal 'Git version 2.20.1 is not supported. Please upgrade to 2.25.0 or higher.'
+    The status should be failure
+  End
+End
+
+
+Describe 'Fails at v1.x versions of git'
+  git() {
+    echo "git version 1.7"
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal 'Git version 1.7 is not supported. Please upgrade to 2.25.0 or higher.'
+    The status should be failure
+  End
+End
+
+
+Describe 'Fails with no versions of git'
+  git() {
+    echo "git version "
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal "Unable to determine git version. Please ensure git is installed and available on your PATH."
+    The status should be failure
+  End
+End
+
+
+Describe 'Fails at empty versions of git'
+  git() {
+    echo ""
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal "Unable to determine git version. Please ensure git is installed and available on your PATH."
+    The status should be failure
+  End
+End
+
+
+Describe 'Fails at cryptic versions of git'
+  git() {
+    echo "something else"
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal "Unable to determine git version. Please ensure git is installed and available on your PATH."
+    The status should be failure
+  End
+End
+
+
+Describe 'Fails at beta versions of git'
+  git() {
+    echo "git version beta-something"
+  }
+
+  It 'Print error message'
+    When run source ./atlas pull --silent test_dir:dir
+    The output should equal "Unable to determine git version. Please ensure git is installed and available on your PATH."
+    The status should be failure
+  End
+End

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -1,6 +1,14 @@
 Describe 'Pull without directory mapping param'
   Include ./atlas
 
+  check_git_version() {
+    true  # skip the git version check
+  }
+
+  git_sparse_checkout_set() {
+    xargs echo "git sparse-checkout set"
+  }
+
   git() {
     echo "git $@"
   }
@@ -24,6 +32,14 @@ End
 
 Describe 'Pull with directory param'
   Include ./atlas
+
+  check_git_version() {
+    true  # skip the git version check
+  }
+
+  git_sparse_checkout_set() {
+    xargs echo "git sparse-checkout set"
+  }
 
   git() {
     echo "git $@"
@@ -74,10 +90,7 @@ git clone --branch=pull_branch --filter=blob:none --no-checkout --depth=1 https:
 cd translations_TEMP
 Done.
 Setting git sparse-checkout rules...
-git sparse-checkout set --no-cone !*
-git sparse-checkout add pull_directory/**
-git sparse-checkout add pull_dir2/**
-git sparse-checkout add missing_pull_dir/**
+git sparse-checkout set --no-cone !* pull_directory/** pull_dir2/** missing_pull_dir/**
 Done.
 Pulling translation files from the repository...
 git checkout HEAD
@@ -106,6 +119,14 @@ End
 
 Describe 'Pull filters'
   Include ./atlas
+
+  check_git_version() {
+    true  # skip the git version check
+  }
+
+  git_sparse_checkout_set() {
+    xargs echo "git sparse-checkout set"
+  }
 
   git() {
     echo "git $@"
@@ -138,13 +159,7 @@ Describe 'Pull filters'
     When call pull_translations
     The output should equal 'git clone --branch=pull_branch --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
 cd translations_TEMP
-git sparse-checkout set --no-cone !*
-git sparse-checkout add pull_directory/**/ar/**
-git sparse-checkout add pull_directory/**/ar.*
-git sparse-checkout add pull_directory/**/es_419/**
-git sparse-checkout add pull_directory/**/es_419.*
-git sparse-checkout add pull_directory/**/fr_CA/**
-git sparse-checkout add pull_directory/**/fr_CA.*
+git sparse-checkout set --no-cone !* pull_directory/**/ar/** pull_directory/**/ar.* pull_directory/**/es_419/** pull_directory/**/es_419.* pull_directory/**/fr_CA/** pull_directory/**/fr_CA.*
 git checkout HEAD
 cd ..'
   End

--- a/spec/verbosity_spec.sh
+++ b/spec/verbosity_spec.sh
@@ -2,6 +2,14 @@ Describe 'Test default verbosity'
   # mock pull translations
   Intercept begin_pull_translations_mock
   __begin_pull_translations_mock__() {
+    check_git_version() {
+      true  # skip the git version check
+    }
+
+    git_sparse_checkout_set() {
+      true  # skip the sparse-checkout rules
+    }
+
     git() {
       if [ "$quiet" ];
       then
@@ -68,6 +76,14 @@ Describe 'Test silent flag'
   # mock pull translations
   Intercept begin_pull_translations_mock
   __begin_pull_translations_mock__() {
+    check_git_version() {
+      true  # skip the git version check
+    }
+
+    git_sparse_checkout_set() {
+      true  # skip the sparse-checkout rules
+    }
+
     git() {
       # Don't check `git sparse-checkout` for `--quiet` because it prints no output.
       if [ "$1" != "sparse-checkout" ];
@@ -140,6 +156,14 @@ Describe 'Test verbose flag'
   # mock pull translations
   Intercept begin_pull_translations_mock
   __begin_pull_translations_mock__() {
+    check_git_version() {
+      true  # skip the git version check
+    }
+
+    git_sparse_checkout_set() {
+      true  # skip the sparse-checkout rules
+    }
+
     git() {
       if [ "$quiet" ];
       then


### PR DESCRIPTION
## Description
Support git v2.25.1 in which `git sparse-checkout add` sub command isn't available. This is a big pull request that ideally should have been a one-liner but bash and unit-testing made it huge:

```diff
-git sparse-checkout set --no-cone "!*"
-git sparse-checkout add "conf/locale/ar/"
-git sparse-checkout add "conf/locale/**/ar.*"
+git sparse-checkout set --no-cone '!*' 'conf/locale/ar/' 'conf/locale/**/ar.*'
```

This pull request introduces `git_sparse_checkout_set` which uses `xargs` to support directories with spaces, although this hasn't been tested.

## Git versions
This pull request adds a GitHub Actions matrix with "default" and specific git versions in an attempt to match the corresponding devstack images below. The "default" git versions uses the latest/default git version from GitHub, which makes it easier to detect failures as `git` deprecates `--no-cone` mode.

| Docker Image                 | Git Version | Support Status |
| ---------------------------- | ----------- | -------------- |
| edxops/credentials:latest    | 2.40.0      | Tested ✅ |
| openedx/lms-dev:latest  | 2.25.1      | Tested ✅ |
| edxops/discovery-dev:latest  | 2.25.1      | Tested ✅ |
| edxops/ecommerce-dev:latest  | 2.25.1      | Tested ✅ |
| openedx/edx-notes-api-dev:latest | 2.25.1   |  Tested ✅  |
| node:16                      | 2.20.1      | Not supported ❌  |
| node:17                      | 2.30.2      | Tested ✅ |
| node:18                      | 2.30.2      | Tested ✅ |


### Not supporting node:16 and git v2.20.1
Some MFEs still have the nodejs v16 which includes git v2.20.1.

While git v2.20.1 internals have partial support for sparse checkout, the command `git sparse-checkout` was introduced only in v2.25+

Therefore, atlas will not support git versions below 2.25 and will produce an error:

```
# sparse-checkout subcommand isn't available in git 2.20.1
$ docker run -it bitnami/git:2.20.1 sparse-checkout
git: 'sparse-checkout' is not a git command. See 'git --help'.

# sparse-checkout subcommand is available in git 2.25.1
$ docker run -it bitnami/git:2.25.1 sparse-checkout
fatal: not a git repository (or any of the parent directories): .git
```

### `--no-cone` mode deprecation
[Git documentation says that `--no-cone` mode would be deprecated](https://www.git-scm.com/docs/git-sparse-checkout#_internalsnon_cone_problems). Nevertheless we're taking a risk here until this is a problem in real world, after which `atlas` needs a refactor to use the state-of-the-art sparse-checkout mode in `git` in future versions.

Therefore the investment in testing to ensure that whenever this is a problem, `atlas` can be adapted to use alternative `git` features.

### Performance degradation on `git v2.25.1`
There's a noticeable slowdown (many seconds) when using v2.25.1 in the initial `git clone --depth=1` compared to more recent git versions like v2.40.1 which executes the commands almost instantly.

The end result of sparse-checkout is identical, therefore no further attempts to improve performance were carried on.


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time