### PR TITLE
feat: add checks and debug for sem-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,25 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Run in dry-run mode to determine the next tag version and store it in semantic-release-next-version.txt
-        npx semantic-release@21.0.7 --dry-run | tee semantic-release-dry-run-output.txt
-        cat semantic-release-dry-run-output.txt \
-          | grep -o 'Skip v.* tag creation in dry-run mode' \
-          | sed -e 's/^Skip //' | sed -e 's/ tag creation in dry-run mode$//' \
-          | tee semantic-release-next-version.txt
+        npx semantic-release@21.0.7 --dry-run | tee semantic-release-next-version.txt
 
-        echo "DEBUG: Next version is '$(cat semantic-release-next-version.txt)'"  # Debug version number
+        NEXT_VERSION=$(
+          cat semantic-release-next-version.txt | \
+            grep -o 'Skip v.* tag creation in dry-run mode' \
+            | sed -e 's/^Skip //' | sed -e 's/ tag creation in dry-run mode$//'
+        )
+
+        echo "DEBUG: Next version is '$NEXT_VERSION'"  # Debug version number
+
+        if [ -z "$NEXT_VERSION" ]; then
+          echo "ERROR: Could not determine next version from semantic-release dry-run output."
+          exit 1
+        fi
 
         # Hardcode the next tag version in the atlas script
-        sed -i -e "s/_ATLAS_VERSION=.*/_ATLAS_VERSION=\"$(cat semantic-release-next-version.txt)\"  # Tagged by release.yml/" atlas
+        sed -i -e "s/_ATLAS_VERSION=.*/_ATLAS_VERSION=\"$NEXT_VERSION\"  # Tagged by release.yml/" atlas
+
+        echo "DEBUG: 'atlas --version' output is '$(./atlas --version)'"  # Debug version number
 
         # Actually create the tag and upload the atlas script
         npx semantic-release@21.0.7


### PR DESCRIPTION
This is mostly an attempt to make the process a bit more robust:

- add one more debug message
- ensure the NEXT_VERSION is not empty before proceeding to release

This PR doesn't address the root cause which broke the the first release https://github.com/openedx/openedx-atlas/actions/runs/5786749334/attempts/1 with a 404 error
```
RequestError [HttpError]: Not Found
    at /home/runner/.npm/_npx/d32d92066bae6c10/node_modules/@octokit/request/dist-node/index.js:112:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async requestWithGraphqlErrorHandling (/home/runner/.npm/_npx/d32d92066bae6c10/node_modules/@octokit/plugin-retry/dist-node/index.js:71:20)
    at async Job.doExecute (/home/runner/.npm/_npx/d32d92066bae6c10/node_modules/bottleneck/light.js:405:18) {
  status: 404,
  response: {
    url: 'https://api.github.com/repos/openedx/openedx-atlas/releases',
    status: 404,
``` 

### Testing

  - [x] Test on my fork: https://github.com/Zeit-Labs/openedx-atlas/releases/tag/v1.1.0


----

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).