### PR TITLE
fix: publish to public npm to avoid breaking CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/openedx/openedx-atlas.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "atlas": "./atlas"
   },


### PR DESCRIPTION
This should fix the following error in CI:

```
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@edx%2fopenedx-atlas - You must sign up for private packages
```

This is aligned with many `@edx` packages configuration e.g. https://github.com/openedx/frontend-lib-content-components/blob/e9c0f6cc8297891925353f430557bd7840e88cd7/package.json#L6-L8

----

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
