### PR TITLE
fix: exit gracefully if not release is needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,45 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: semantic release
+
+    - name: Determine next tag version
       env:
         GITHUB_TOKEN: ${{ github.token }}
         NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
       run: |
-        # Run in dry-run mode to determine the next tag version and store it in semantic-release-next-version.txt
-        npx semantic-release@21.0.7 --dry-run | tee semantic-release-next-version.txt
+        # Run in dry-run mode to determine the next tag version and store it in semantic-release-dry-run.txt
+        npx semantic-release@21.0.7 --dry-run | tee semantic-release-dry-run.txt
+
+        if grep -q 'no new version is released' semantic-release-dry-run.txt; then
+          RELEASE_NEEDED=no
+        else
+          RELEASE_NEEDED=yes
+        fi
+
+        echo "RELEASE_NEEDED=$RELEASE_NEEDED" >> $GITHUB_ENV
 
         NEXT_VERSION=$(
-          cat semantic-release-next-version.txt | \
+          cat semantic-release-dry-run.txt | \
             grep -o 'Skip v.* tag creation in dry-run mode' \
             | sed -e 's/^Skip //' | sed -e 's/ tag creation in dry-run mode$//'
         )
+        echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
 
+        echo "DEBUG: RELEASE_NEEDED = '$RELEASE_NEEDED' "
         echo "DEBUG: Next version is '$NEXT_VERSION'"  # Debug version number
 
-        if [ -z "$NEXT_VERSION" ]; then
-          echo "ERROR: Could not determine next version from semantic-release dry-run output."
-          exit 1
-        fi
+    - name: Fail if release is needed but version number is not set
+      if: env.RELEASE_NEEDED == 'yes' && env.NEXT_VERSION == ''
+      run: |
+        echo "ERROR: Could not determine next version from semantic-release dry-run output."
+        exit 1
 
+    - name: Release to both GitHub and npm
+      if: env.NEXT_VERSION
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      run: |
         # Hardcode the next tag version in the atlas script
         sed -i -e "s/_ATLAS_VERSION=.*/_ATLAS_VERSION=\"$NEXT_VERSION\"  # Tagged by release.yml/" atlas
 


### PR DESCRIPTION
Otherwise `release.yml` will fail needlessly.

Fixes #40 