### PR TITLE
fix: build pypi package after tagging the version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,20 @@ jobs:
     - name: Install Dependencies
       run: pip install setuptools wheel
 
-    - name: Build package
-      run: python setup.py sdist bdist_wheel
-
     - name: Update the tag version in setup.py
       if: env.NEXT_VERSION
       run: |
         NEXT_VERSION_PYPI=${NEXT_VERSION:1}  # Remove the leading 'v' to match PyPi's versioning scheme
         sed -i -e "s/version=.*,/version='$NEXT_VERSION_PYPI'  # tagged by release.yml,/" setup.py
-        cat setup.py
+        cat setup.py  # Debug setup.py output
+
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+
+    - name: Print built package version
+      run: |
+        echo "DEBUG: checking the version within the pip wheel .whl file"
+        less dist/*.whl | head -n 20
 
     - name: Publish to PyPi
       if: env.NEXT_VERSION


### PR DESCRIPTION
Also adds a couple of debugging to ensure `sed` is doing its job correctly.


This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
