### PR TITLE
fix: support Apple Git

### DIFF
--- a/atlas
+++ b/atlas
@@ -451,7 +451,7 @@ display_pull_params() {
 
 check_git_version() {
   MINIMUM_GIT_VERSION="2.25.0"  # The `git sparse-checkout` subcommand was introduced in 2.25.0
-  GIT_VERSION=$(git --version | grep 'git version' | sed -e 's/git version //g')
+  GIT_VERSION=$(git --version | grep 'git version' | sed -e 's/ .Apple Git-.*//gI' | sed -e 's/git version //g')
 
   # Check if GIT_VERSION is a valid version number
   if ! echo "$GIT_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,3}$';

--- a/spec/minimum_git_version_spec.sh
+++ b/spec/minimum_git_version_spec.sh
@@ -28,6 +28,35 @@ Describe 'Works on version 2.25.0'
 End
 
 
+Describe 'Works on Apple git 2.39.3 / Apple Git-146'
+  git() {
+    echo 'git version 2.39.3 (Apple Git-146)'
+  }
+
+  Include ./atlas
+
+  It 'Works'
+    When call check_git_version
+    The status should be success
+  End
+End
+
+
+Describe 'Fails on Apple git 2.19.3 / Apple Git-50'
+  git() {
+    echo 'git version 2.19.3 (Apple Git-50)'
+  }
+
+  Include ./atlas
+
+  It 'Detect the version correctly and fails'
+    When call check_git_version
+    The output should equal 'Git version 2.19.3 is not supported. Please upgrade to 2.25.0 or higher.'
+    The status should be failure
+  End
+End
+
+
 Describe 'Require git version 2.25.0 at least'
   git() {
     echo "git version 2.20.1"


### PR DESCRIPTION
### Bug fix

Ensure atlas reads `git --version` correctly when the output is

```bash
$ git --version  # On Mac
git version 2.39.3 (Apple Git-146)
```

The `(Apple Git-146)` is confusing Atlas version check.


Beause it was designed with more standard git output in mind:
```bash
$ git --version  # On Linux, with the GitHub CLI
git version 2.34.1
hub version 2.14.2
```

### Related issues
 
 - Fixes #53 


### Test locally

```
cd ~/bin/
curl -L https://github.com/Zeit-Labs/openedx-atlas/raw/apple_git/atlas -o atlas
chmod +x atlas
atlas --version
```

### Slack thread

 - [Slack thread by Volo](https://openedx.slack.com/archives/C06RU4ZJ42V/p1717580570439449)