### PR TITLE
feat: Allow pulling translations from a commit hash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ regularly and useful to understand ``atlas`` at a glance.
             slug of the GitHub repository to pull from. Defaults 'openedx/openedx-translations'.
 
         `-n` or `--revision`:
-            Git revision to pull from. Currently only branches and tags are supported. Defaults to 'main'.
+            Git revision to pull from. Support branches, tags, and commits hashes. Defaults to 'main'.
 
             This option name used to be `-b` or `--branch`. The deprecated name will be removed in a future release.
 

--- a/atlas
+++ b/atlas
@@ -47,7 +47,7 @@ Options:
         slug of the GitHub repository to pull from. Defaults 'openedx/openedx-translations'.
 
     \`-n\` or \`--revision\`:
-        Git revision to pull from. Currently only branches and tags are supported. Defaults to 'main'.
+        Git revision to pull from. Support branches, tags, and commits hashes. Defaults to 'main'.
 
         This option name used to be \`-b\` or \`--branch\`. The deprecated name will be removed in a future release.
 
@@ -200,7 +200,7 @@ Options:
         slug of the GitHub repository to pull from. Defaults 'openedx/openedx-translations'.
 
     `-n` or `--revision`:
-        Git revision to pull from. Currently only branches and tags are supported. Defaults to 'main'.
+        Git revision to pull from. Support branches, tags, and commits hashes. Defaults to 'main'.
 
         This option name used to be `-b` or `--branch`. The deprecated name will be removed in a future release.
 
@@ -507,18 +507,21 @@ pull_translations() {
     quiet="--quiet"
   fi
 
-  if [ "$pull_revision" ];
-  then
-    pull_revision_argument="--branch=${pull_revision}"
-  else
-    pull_revision_argument=""
-  fi
 
   # Creating a shallow clone of the repo without without pulling the files yet
-  # shellcheck disable=SC2086
-  git clone $quiet $pull_revision_argument --filter=blob:none --no-checkout --depth=1 \
-            "https://github.com/${pull_repository}.git" translations_TEMP || exit
+  git init $quiet translations_TEMP || exit
   cd translations_TEMP || exit
+  git remote add origin "https://github.com/${pull_repository}.git" || exit
+  # Requires server to allow pulling commits by direct commit hash reference,
+  # controlled by uploadpack.allowAnySHA1InWant and related configs. (GitHub
+  # does allow this, though.)
+  #
+  # The `remote.<name>.promisor` config override is needed for git 2.25 and possibly
+  # later versions (but not in 2.30 and later). In some earlier versions it might
+  # instead need to be written as `extensions.partialClone=origin` -- 2.25.1 mentions
+  # this in its output if a promisor is not set, but doesn't actually *use* that config.
+  git -c remote.origin.promisor=true fetch \
+      $quiet --filter=blob:none --depth=1 origin "${pull_revision:-main}" || exit
 
   # finished "Creating a temporary Git repository to pull translations into <temp dir>..." step
   if [ -z "$SILENT" ];
@@ -564,7 +567,7 @@ pull_translations() {
   fi
 
   # Retrieve translation files from the repo
-  git checkout HEAD
+  git checkout $quiet FETCH_HEAD
 
   # Remove .git directory
   rm -rf .git

--- a/spec/pull_spec.sh
+++ b/spec/pull_spec.sh
@@ -86,14 +86,16 @@ Describe 'Pull with directory param'
   It 'calls everything properly with multiple directories'
     When call pull_translations
     The output should equal 'Creating a temporary Git repository to pull translations into "./translations_TEMP"...
-git clone --branch=pull_revision --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
+git init translations_TEMP
 cd translations_TEMP
+git remote add origin https://github.com/pull_repository.git
+git -c remote.origin.promisor=true fetch --filter=blob:none --depth=1 origin pull_revision
 Done.
 Setting git sparse-checkout rules...
 git sparse-checkout set --no-cone !* pull_directory/** pull_dir2/** missing_pull_dir/**
 Done.
 Pulling translation files from the repository...
-git checkout HEAD
+git checkout FETCH_HEAD
 rm -rf .git
 cd ..
 mkdir -p local_dir
@@ -157,10 +159,12 @@ Describe 'Pull filters'
 
   It 'sets correct sparse-checkout rules'
     When call pull_translations
-    The output should equal 'git clone --branch=pull_revision --filter=blob:none --no-checkout --depth=1 https://github.com/pull_repository.git translations_TEMP
+    The output should equal 'git init translations_TEMP
 cd translations_TEMP
+git remote add origin https://github.com/pull_repository.git
+git -c remote.origin.promisor=true fetch --filter=blob:none --depth=1 origin pull_revision
 git sparse-checkout set --no-cone !* pull_directory/**/ar/** pull_directory/**/ar.* pull_directory/**/es_419/** pull_directory/**/es_419.* pull_directory/**/fr_CA/** pull_directory/**/fr_CA.*
-git checkout HEAD
+git checkout FETCH_HEAD
 cd ..'
   End
 End


### PR DESCRIPTION
By switching from clone to an explicit init+fetch we can get better control of what commits are fetched. clone only allows targeting a branch or a tag, but fetch can ask for any commit. The caveat is that the server needs to allow this via `uploadpack.allowReachableSHA1InWant` and similar.

Minor changes:

- checkout is now also quiet by default

----

For testing, I entered the edx-platform repo and made calls like the following:

```
../openedx-atlas/atlas pull --revision=986a87b76532a95f2f9fd460cc3fb6bf7692a8f0 \
  translations/edx-platform/conf/locale:conf/locale \
  translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend
```

In between tests I cleared state with `rm -rf conf/locale/ conf/plugins-locale/ translations_TEMP/; git checkout conf/`.

I didn't check translations files directly, but I did use `du -bs .` to confirm that the published atlas and my patched version caused the same increase in total file size in the repo, which seemed like a good proxy.