### PR TITLE
feat: Support flexible Git repository URLs for translations

### DIFF
--- a/atlas
+++ b/atlas
@@ -512,11 +512,17 @@ pull_translations() {
     quiet="--quiet"
   fi
 
+  if [[ "$pull_repository" =~ ^(https?|git@|ssh://).* ]]; then
+    repo_url="$pull_repository"
+  else
+    # Fallback to the original GitHub format
+    repo_url="https://github.com/${pull_repository}.git"
+  fi
 
   # Creating a shallow clone of the repo without without pulling the files yet
   git init $quiet translations_TEMP || exit
   cd translations_TEMP || exit
-  git remote add origin "https://github.com/${pull_repository}.git" || exit
+  git remote add origin "$repo_url" || exit
   # Requires server to allow pulling commits by direct commit hash reference,
   # controlled by uploadpack.allowAnySHA1InWant and related configs. (GitHub
   # does allow this, though.)


### PR DESCRIPTION
**Overview:**
This PR introduces support for pulling translations from additional sources beyond public GitHub repositories. The existing implementation works well for open-source projects, but it's limiting for teams using private repositories or other version control systems.

**Motivation:**
At RaccoonGang, we primarily work with GitLab. The current translation workflow requires workarounds to handle these cases, which affects efficiency and maintainability.

**What's Added:**
* Support for GitLab repositories (both public and private)
* Support for private GitHub repositories with authentication
* Refactored source handling logic to allow extensibility for other VCS platforms in the future

**Next Steps:**
Feedback is welcome on the approach and implementation. I'm happy to iterate to better align with the project's direction and standards.

**Related issue:** https://github.com/openedx/openedx-atlas/issues/63