### PR TITLE
fix(ci): trust third-party taps and compile git before Homebrew setup

### DIFF
--- a/.github/workflows/git-tests.yml
+++ b/.github/workflows/git-tests.yml
@@ -37,19 +37,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y shellcheck
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-    - name: install shellspec
-      run: |
-        brew tap shellspec/shellspec
-        brew install shellspec
-    - name: install getoptions
-      run: |
-        brew tap ko1nksm/getoptions
-        brew install getoptions
 
     - name: install custom version of git
+      # Must run before Set up Homebrew to avoid Homebrew's LDFLAGS/CPPFLAGS interfering with ./configure.
       run: |
         sudo apt install gettext libcurl4-openssl-dev libexpat1-dev libz-dev libssl-dev
         wget --no-verbose https://mirrors.edge.kernel.org/pub/software/scm/git/git-${{ matrix.git_version }}.tar.gz
@@ -60,6 +50,20 @@ jobs:
         make all
         sudo make install
       if: matrix.git_version != 'default'
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: install shellspec
+      run: |
+        brew tap shellspec/shellspec
+        brew trust shellspec/shellspec
+        brew install shellspec
+    - name: install getoptions
+      run: |
+        brew tap ko1nksm/getoptions
+        brew trust ko1nksm/getoptions
+        brew install getoptions
 
     - name: print git version
       run: git --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,12 @@ jobs:
     - name: install shellspec
       run: |
         brew tap shellspec/shellspec
+        brew trust shellspec/shellspec
         brew install shellspec
     - name: install getoptions
       run: |
         brew tap ko1nksm/getoptions
+        brew trust ko1nksm/getoptions
         brew install getoptions
     - name: run shellspec
       run: shellspec
@@ -37,10 +39,12 @@ jobs:
     - name: install shellspec
       run: |
         brew tap shellspec/shellspec
+        brew trust shellspec/shellspec
         brew install shellspec
     - name: install getoptions
       run: |
         brew tap ko1nksm/getoptions
+        brew trust ko1nksm/getoptions
         brew install getoptions
     - name: run shellspec
       run: shellspec


### PR DESCRIPTION
## Problem

Since ~2026-07-13, the `ubuntu-22.04-git-2.40.1` and `ubuntu-22.04-git-2.30.2` matrix jobs in `git-tests.yml` fail with:

```
git: 'remote-https' is not a git command. See 'git --help'.
```

Jobs in `test.yml` were also failing with:

```
Refusing to load formula ... from untrusted tap
```

## Root cause

**Untrusted taps:** Newer Homebrew requires `brew trust <tap>` before installing from a third-party tap. Both `test.yml` and `git-tests.yml` were missing this for `shellspec/shellspec` and `ko1nksm/getoptions`.

**`git-remote-https` not compiled:** The `Homebrew/actions/setup-homebrew` step injects `LDFLAGS` and `CPPFLAGS` pointing to Homebrew's own lib/include paths. When custom git compilation ran *after* this step, autoconf's `AC_CHECK_LIB(curl)` link test silently failed (Homebrew paths shadowed system libcurl), so `git-remote-https` was never built — causing the HTTPS transport error at test time.

## Fix

1. **`brew trust`** — added `brew trust shellspec/shellspec` and `brew trust ko1nksm/getoptions` to both `test.yml` and `git-tests.yml`.
2. **Step reorder** — moved the custom git compile step to run **before** `Set up Homebrew` in `git-tests.yml`, so `./configure` sees the clean system environment and correctly detects libcurl.

## Testing

CI confirmed — all checks green.