### PR TITLE
fix(ci): capture stderr in release dry-run so NEXT_VERSION parses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
       run: |
         # Run in dry-run mode to determine the next tag version and store it in semantic-release-dry-run.txt
-        FORCE_COLOR=0 npx semantic-release@25 --dry-run | tee semantic-release-dry-run.txt
+        FORCE_COLOR=0 npx semantic-release@25 --dry-run 2>&1 | tee semantic-release-dry-run.txt
 
         if grep -q 'no new version is released' semantic-release-dry-run.txt; then
           RELEASE_NEEDED=no


### PR DESCRIPTION
## Problem

The Release CI fails at the **"Fail if release is needed but version number is not set"** step even when a release is clearly needed (e.g. [this run](https://github.com/openedx/openedx-atlas/actions/runs/30824644767/job/91723010985), which computed `0.7.1`). The job log shows `RELEASE_NEEDED: yes` but `NEXT_VERSION:` empty.

## Root cause

`semantic-release` writes its `⚠` **warn** messages to **stderr** (see [`get-logger.js`](https://github.com/semantic-release/semantic-release/blob/master/lib/get-logger.js) — `stream: [stderr]` for warn/error, stdout otherwise). The line the workflow greps for is one of those:

```
[semantic-release] › ⚠  Skip v0.7.1 tag creation in dry-run mode
```

But the dry-run step piped only stdout into the file:

```bash
npx semantic-release@25 --dry-run | tee semantic-release-dry-run.txt
```

`tee` captures stdout only, so that line is visible in the Actions console but never lands in `semantic-release-dry-run.txt`. The grep on it returns nothing → `NEXT_VERSION` is empty → the guard step exits 1.

This also explains why the "no release" path worked: the `ℹ no new version is released` line is an *info* message on stdout, so `RELEASE_NEEDED=no` was detected correctly. The `FORCE_COLOR=0` change in #72 was addressing the wrong culprit (ANSI codes).

## Fix

Add `2>&1` so `tee` captures the full log:

```bash
FORCE_COLOR=0 npx semantic-release@25 --dry-run 2>&1 | tee semantic-release-dry-run.txt
```

## Verification

Reproduced locally (node 24 via `nvm use`), running the dry-run both ways:

- **`| tee`** (old): the `Skip v0.7.1 …` line prints to the terminal but is absent from the file → grep NOT FOUND → `NEXT_VERSION` empty.
- **`2>&1 | tee`** (fixed): the line is in the file → parses `NEXT_VERSION = v0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)